### PR TITLE
fix: correct icon manifest paths

### DIFF
--- a/frontend/public/icons/browserconfig.xml
+++ b/frontend/public/icons/browserconfig.xml
@@ -22,7 +22,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
+            <square150x150logo src="/icons/mstile-150x150.png"/>
             <TileColor>#1e6581</TileColor>
         </tile>
     </msapplication>

--- a/frontend/public/icons/manifest.webmanifest
+++ b/frontend/public/icons/manifest.webmanifest
@@ -4,77 +4,77 @@
     "start_url": "/",
     "icons": [
         {
-            "src": "/maskable72.png",
+            "src": "/icons/maskable72.png",
             "sizes": "72x72",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable76.png",
+            "src": "/icons/maskable76.png",
             "sizes": "76x76",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable96.png",
+            "src": "/icons/maskable96.png",
             "sizes": "96x96",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable120.png",
+            "src": "/icons/maskable120.png",
             "sizes": "120x120",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable128.png",
+            "src": "/icons/maskable128.png",
             "sizes": "128x128",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable144.png",
+            "src": "/icons/maskable144.png",
             "sizes": "144x144",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable152.png",
+            "src": "/icons/maskable152.png",
             "sizes": "152x152",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable180.png",
+            "src": "/icons/maskable180.png",
             "sizes": "180x180",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable192.png",
+            "src": "/icons/maskable192.png",
             "sizes": "192x192",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable384.png",
+            "src": "/icons/maskable384.png",
             "sizes": "384x384",
             "type": "image/png",
             "scope": "maskable",
             "purpose": "maskable any"
         },
         {
-            "src": "/maskable512.png",
+            "src": "/icons/maskable512.png",
             "sizes": "512x512",
             "type": "image/png",
             "scope": "maskable",


### PR DESCRIPTION
## Summary
- fix icon URLs in web manifest
- update browser config to reference icons

## Testing
- `npm run lint`
- `curl -I http://localhost:3000/icons/maskable72.png`
- `curl -I http://localhost:3000/icons/mstile-150x150.png`
- `curl -I http://localhost:3000/fonts/Roboto-Regular-latin.woff2`

------
https://chatgpt.com/codex/tasks/task_b_689dee4a37e0833293246a899dfbb3ca