### PR TITLE
feat: add shared layout component

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,15 @@
 
+import Layout from "../components/Layout";
+
 export default function Home() {
     return (
-        <div className="font-sans min-h-screen flex items-center justify-center p-8">
-            <main className="text-center">
-                <h1 className="text-4xl font-bold mb-4">Welcome to Firefly III</h1>
-                <p className="text-lg">Your Next.js app is ready to go.</p>
-            </main>
-        </div>
+        <Layout title="Home">
+            <div className="font-sans min-h-screen flex items-center justify-center p-8">
+                <main className="text-center">
+                    <h1 className="text-4xl font-bold mb-4">Welcome to Firefly III</h1>
+                    <p className="text-lg">Your Next.js app is ready to go.</p>
+                </main>
+            </div>
+        </Layout>
     );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,39 @@
+import Head from "next/head";
+import Link from "next/link";
+import React, { ReactNode } from "react";
+
+interface LayoutProps {
+    children: ReactNode;
+    title?: string;
+}
+
+export default function Layout({children, title}: LayoutProps) {
+    const pageTitle = title ? `${title} » Firefly III` : "Firefly III";
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <div className="wrapper" id="app">
+                <header className="main-header">
+                    <Link href="/" className="logo">
+                        <span className="logo-mini">FF</span>
+                        <span className="logo-lg"><strong>Firefly</strong>III</span>
+                    </Link>
+                </header>
+                <aside className="main-sidebar">
+                    <section className="sidebar"></section>
+                </aside>
+                <div className="content-wrapper">
+                    <section className="content-header"></section>
+                    <section className="content">{children}</section>
+                </div>
+                <footer className="main-footer">
+                    <strong><a href="https://github.com/firefly-iii/firefly-iii">Firefly III</a></strong>
+                </footer>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- mirror default Twig layout in reusable React component
- wrap pages in shared layout for consistent header and footer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689df2af755c83329d6373cdb121b0d3