### PR TITLE
Add Next.js sample home page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,13 +1,24 @@
 
+import Image from "next/image";
+import Link from "next/link";
 import Layout from "../components/Layout";
 
 export default function Home() {
     return (
         <Layout title="Home">
-            <div className="font-sans min-h-screen flex items-center justify-center p-8">
-                <main className="text-center">
-                    <h1 className="text-4xl font-bold mb-4">Welcome to Firefly III</h1>
+            <div className="font-sans min-h-screen flex flex-col items-center justify-center p-8">
+                <main className="text-center space-y-4">
+                    <h1 className="text-4xl font-bold">Welcome to Firefly III</h1>
                     <p className="text-lg">Your Next.js app is ready to go.</p>
+                    <Image src="/next.svg" alt="Next.js Logo" width={180} height={37} />
+                    <p>
+                        <Link
+                            href="https://github.com/firefly-iii/firefly-iii"
+                            className="text-blue-500 underline"
+                        >
+                            View on GitHub
+                        </Link>
+                    </p>
                 </main>
             </div>
         </Layout>


### PR DESCRIPTION
## Summary
- add sample home page that renders inside Layout component
- include sample asset and link to demonstrate navigation

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_b_689df58532a48332956857cf588ecc3c