### PR TITLE
feat(frontend): add accounts page

### DIFF
--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Layout from "../../components/Layout";
+
+interface Account {
+    id: number;
+    name: string;
+}
+
+export default function AccountsPage() {
+    const [accounts, setAccounts] = useState<Account[]>([]);
+
+    useEffect(() => {
+        async function loadAccounts() {
+            try {
+                const response = await fetch("/api/accounts");
+                if (response.ok) {
+                    const data = await response.json();
+                    setAccounts(data);
+                }
+            } catch {
+                // API not available yet
+            }
+        }
+        loadAccounts();
+    }, []);
+
+    return (
+        <Layout title="Accounts">
+            <div className="box" id="account-index">
+                <div className="box-header with-border">
+                    <h3 className="box-title">Accounts</h3>
+                    <div className="box-tools pull-right">
+                        <Link href="/accounts/create" className="btn btn-success">
+                            + New account
+                        </Link>
+                    </div>
+                </div>
+                <div className="box-body">
+                    {accounts.length > 0 ? (
+                        <ul>
+                            {accounts.map(account => (
+                                <li key={account.id}>{account.name}</li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p>No accounts yet.</p>
+                    )}
+                </div>
+            </div>
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,6 +19,11 @@ export default function Home() {
                             View on GitHub
                         </Link>
                     </p>
+                    <p>
+                        <Link href="/accounts" className="text-blue-500 underline">
+                            Accounts
+                        </Link>
+                    </p>
                 </main>
             </div>
         </Layout>


### PR DESCRIPTION
## Summary
- add Next.js Accounts page that fetches accounts and lists them
- link from home page to accounts section

## Testing
- `cd frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689df7e2bd2c8332b6a3482202fb14c6