### PR TITLE
feat(frontend): add pages for legacy twig templates

### DIFF
--- a/frontend/src/app/debug/page.tsx
+++ b/frontend/src/app/debug/page.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import Link from "next/link";
+
+interface DebugData {
+    now: string;
+    ffVersion: string;
+    table: string;
+    logContent: string;
+    backText: string;
+}
+
+async function getDebugData(): Promise<DebugData> {
+    const res = await fetch("/api/debug", { cache: "no-store" });
+    return res.json();
+}
+
+export default async function DebugPage() {
+    const data = await getDebugData();
+    return (
+        <div className="p-4 space-y-4 font-sans">
+            <p dangerouslySetInnerHTML={{ __html: data.table }} />
+            <textarea
+                rows={30}
+                cols={100}
+                defaultValue={`Debug information generated at ${data.now} for Firefly III version ${data.ffVersion}.\n\n${data.table}`}
+                className="w-full font-mono text-xs"
+                readOnly
+            />
+            <p>
+                <Link href="/">{data.backText}</Link>
+            </p>
+            <textarea
+                rows={30}
+                cols={100}
+                defaultValue={data.logContent}
+                className="w-full font-mono text-xs"
+                readOnly
+            />
+            <p>
+                <Link href="/">{data.backText}</Link>
+            </p>
+        </div>
+    );
+}
+

--- a/frontend/src/app/error/page.tsx
+++ b/frontend/src/app/error/page.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import Link from "next/link";
+
+interface ErrorPageProps {
+    searchParams: { [key: string]: string | string[] | undefined };
+}
+
+export default function ErrorPage({ searchParams }: ErrorPageProps) {
+    const message = typeof searchParams.message === "string" ? searchParams.message : "General unknown error";
+    return (
+        <div className="p-4 space-y-4 font-sans">
+            <h3 className="text-red-600">Sorry, an error occurred.</h3>
+            <p dangerouslySetInnerHTML={{ __html: message }} />
+            <p>
+                If you do not know how to handle this error, please open an issue on
+                <a className="text-blue-500" href="https://github.com/firefly-iii/firefly-iii/issues"> GitHub</a>
+                or <a className="text-blue-500" href="mailto:james@firefly-iii.org">send me a message</a>.
+            </p>
+            <p>
+                <Link href="/">Follow this link back to the index.</Link>
+            </p>
+        </div>
+    );
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,21 +1,27 @@
-
 import Image from "next/image";
 import Link from "next/link";
 import Layout from "../components/Layout";
 
-export default function Home() {
+interface IndexData {
+    message: string;
+}
+
+async function getIndexData(): Promise<IndexData> {
+    const res = await fetch("/api/index", { cache: "no-store" });
+    return res.json();
+}
+
+export default async function Home() {
+    const data = await getIndexData();
     return (
         <Layout title="Home">
             <div className="font-sans min-h-screen flex flex-col items-center justify-center p-8">
                 <main className="text-center space-y-4">
                     <h1 className="text-4xl font-bold">Welcome to Firefly III</h1>
-                    <p className="text-lg">Your Next.js app is ready to go.</p>
+                    <p className="text-lg">{data.message}</p>
                     <Image src="/next.svg" alt="Next.js Logo" width={180} height={37} />
                     <p>
-                        <Link
-                            href="https://github.com/firefly-iii/firefly-iii"
-                            className="text-blue-500 underline"
-                        >
+                        <Link href="https://github.com/firefly-iii/firefly-iii" className="text-blue-500 underline">
                             View on GitHub
                         </Link>
                     </p>
@@ -24,3 +30,4 @@ export default function Home() {
         </Layout>
     );
 }
+

--- a/frontend/src/app/pwa/page.tsx
+++ b/frontend/src/app/pwa/page.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { promises as fs } from "fs";
+import path from "path";
+
+async function getPwaHtml(): Promise<string> {
+    const filePath = path.join(process.cwd(), "public", "v3", "index.html");
+    try {
+        return await fs.readFile(filePath, "utf8");
+    } catch {
+        return "<p>PWA not available</p>";
+    }
+}
+
+export default async function PwaPage() {
+    const html = await getPwaHtml();
+    return <div dangerouslySetInnerHTML={{ __html: html }} />;
+}
+


### PR DESCRIPTION
## Summary
- create Next.js pages for old debug, error, and PWA Twig templates
- fetch index content and display via data props
- add server-side file loading for PWA HTML

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `composer test` *(fails: Command "test" is not defined)*
- `composer unit-test` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_b_689dfad1cc048332a9bab3d89dbbceec