### PR TITLE
feat(frontend): add accounts pages

### DIFF
--- a/frontend/src/app/accounts/AccountForm.tsx
+++ b/frontend/src/app/accounts/AccountForm.tsx
@@ -1,0 +1,101 @@
+'use client';
+import React, {FormEvent, useState} from 'react';
+import {useRouter} from 'next/navigation';
+
+interface Account {
+    name: string;
+    iban?: string;
+    bic?: string;
+    accountNumber?: string;
+    notes?: string;
+}
+
+interface AccountFormProps {
+    initialData?: Account;
+    accountId?: string;
+}
+
+export default function AccountForm({initialData, accountId}: AccountFormProps) {
+    const [formData, setFormData] = useState<Account>(initialData ?? {
+        name: '',
+        iban: '',
+        bic: '',
+        accountNumber: '',
+        notes: '',
+    });
+    const router = useRouter();
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        setFormData({...formData, [e.target.name]: e.target.value});
+    };
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        const method = accountId ? 'PUT' : 'POST';
+        const url = accountId ? `/api/accounts/${accountId}` : '/api/accounts';
+        await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(formData),
+        });
+        router.push('/accounts');
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+                <label htmlFor="name" className="block font-medium">Name</label>
+                <input
+                    id="name"
+                    name="name"
+                    className="border p-2 w-full"
+                    value={formData.name}
+                    onChange={handleChange}
+                    required
+                />
+            </div>
+            <div>
+                <label htmlFor="iban" className="block font-medium">IBAN</label>
+                <input
+                    id="iban"
+                    name="iban"
+                    className="border p-2 w-full"
+                    value={formData.iban}
+                    onChange={handleChange}
+                />
+            </div>
+            <div>
+                <label htmlFor="bic" className="block font-medium">BIC</label>
+                <input
+                    id="bic"
+                    name="bic"
+                    className="border p-2 w-full"
+                    value={formData.bic}
+                    onChange={handleChange}
+                />
+            </div>
+            <div>
+                <label htmlFor="accountNumber" className="block font-medium">Account Number</label>
+                <input
+                    id="accountNumber"
+                    name="accountNumber"
+                    className="border p-2 w-full"
+                    value={formData.accountNumber}
+                    onChange={handleChange}
+                />
+            </div>
+            <div>
+                <label htmlFor="notes" className="block font-medium">Notes</label>
+                <textarea
+                    id="notes"
+                    name="notes"
+                    className="border p-2 w-full"
+                    value={formData.notes}
+                    onChange={handleChange}
+                />
+            </div>
+            <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">Save</button>
+        </form>
+    );
+}
+

--- a/frontend/src/app/accounts/DeleteAccountForm.tsx
+++ b/frontend/src/app/accounts/DeleteAccountForm.tsx
@@ -1,0 +1,22 @@
+'use client';
+import React from 'react';
+import {useRouter} from 'next/navigation';
+
+interface Props {
+    accountId: string;
+}
+
+export default function DeleteAccountForm({accountId}: Props) {
+    const router = useRouter();
+    const handleDelete = async () => {
+        await fetch(`/api/accounts/${accountId}`, {method: 'DELETE'});
+        router.push('/accounts');
+    };
+
+    return (
+        <button onClick={handleDelete} className="bg-red-600 text-white px-4 py-2 rounded">
+            Delete
+        </button>
+    );
+}
+

--- a/frontend/src/app/accounts/[id]/delete/page.tsx
+++ b/frontend/src/app/accounts/[id]/delete/page.tsx
@@ -1,0 +1,17 @@
+import Layout from '../../../../components/Layout';
+import DeleteAccountForm from '../../DeleteAccountForm';
+
+interface Props {
+    params: { id: string };
+}
+
+export default function DeleteAccountPage({ params }: Props) {
+    return (
+        <Layout title="Delete Account">
+            <h1 className="text-2xl mb-4">Delete Account</h1>
+            <p className="mb-4">Are you sure you want to delete this account?</p>
+            <DeleteAccountForm accountId={params.id} />
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/accounts/[id]/edit/page.tsx
+++ b/frontend/src/app/accounts/[id]/edit/page.tsx
@@ -1,0 +1,21 @@
+import Layout from '../../../../components/Layout';
+import AccountForm from '../../AccountForm';
+
+interface Props {
+    params: { id: string };
+}
+
+async function getAccount(id: string) {
+    return { name: `Account ${id}`, iban: 'DE00', bic: 'TESTBIC', accountNumber: '123456', notes: 'Demo account' };
+}
+
+export default async function EditAccountPage({ params }: Props) {
+    const account = await getAccount(params.id);
+    return (
+        <Layout title="Edit Account">
+            <h1 className="text-2xl mb-4">Edit Account</h1>
+            <AccountForm initialData={account} accountId={params.id} />
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/accounts/[id]/page.tsx
+++ b/frontend/src/app/accounts/[id]/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Layout from '../../../components/Layout';
+
+interface Props {
+    params: { id: string };
+}
+
+async function getAccount(id: string) {
+    return { id, name: `Account ${id}`, iban: 'DE00', bic: 'TESTBIC', accountNumber: '123456', notes: 'Demo account' };
+}
+
+export default async function ShowAccountPage({ params }: Props) {
+    const account = await getAccount(params.id);
+    return (
+        <Layout title={account.name}>
+            <h1 className="text-2xl mb-4">{account.name}</h1>
+            <p>IBAN: {account.iban}</p>
+            <p>BIC: {account.bic}</p>
+            <p>Account Number: {account.accountNumber}</p>
+            <p>Notes: {account.notes}</p>
+            <div className="mt-4 space-x-4">
+                <Link href={`/accounts/${account.id}/edit`} className="text-blue-500 underline">Edit</Link>
+                <Link href={`/accounts/${account.id}/delete`} className="text-red-500 underline">Delete</Link>
+            </div>
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/accounts/create/page.tsx
+++ b/frontend/src/app/accounts/create/page.tsx
@@ -1,0 +1,12 @@
+import Layout from '../../../components/Layout';
+import AccountForm from '../AccountForm';
+
+export default function CreateAccountPage() {
+    return (
+        <Layout title="Create Account">
+            <h1 className="text-2xl mb-4">Create Account</h1>
+            <AccountForm />
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/accounts/page.tsx
+++ b/frontend/src/app/accounts/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+
+async function getAccounts() {
+    return [
+        {id: '1', name: 'Checking'},
+        {id: '2', name: 'Savings'},
+    ];
+}
+
+export default async function AccountsIndex() {
+    const accounts = await getAccounts();
+    return (
+        <Layout title="Accounts">
+            <h1 className="text-2xl mb-4">Accounts</h1>
+            <div className="mb-4">
+                <Link href="/accounts/create" className="text-blue-500 underline">
+                    Create Account
+                </Link>
+            </div>
+            <ul className="space-y-2">
+                {accounts.map((account) => (
+                    <li key={account.id}>
+                        <Link href={`/accounts/${account.id}`} className="text-blue-600 underline">
+                            {account.name}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </Layout>
+    );
+}
+


### PR DESCRIPTION
## Summary
- scaffold accounts pages in Next.js app for index, create, show, edit, and delete routes
- add reusable client-side account form and delete confirmation handler

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689dfb6955d4833295a86929600855f6