### PR TITLE
feat(frontend): port currency views and fetch exchange rates

### DIFF
--- a/frontend/src/app/currencies/[code]/delete/page.tsx
+++ b/frontend/src/app/currencies/[code]/delete/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import {useRouter, useParams} from 'next/navigation';
+import Layout from '../../../../components/Layout';
+
+export default function DeleteCurrency() {
+    const router = useRouter();
+    const params = useParams();
+    const code = params?.code as string;
+
+    const handleDelete = async () => {
+        await fetch(`/api/v1/currencies/${code}`, {method: 'DELETE'});
+        router.push('/currencies');
+    };
+
+    return (
+        <Layout title={`Delete ${code}`}>
+            <div className="box box-danger">
+                <div className="box-body">
+                    <p>Are you sure you want to delete {code}?</p>
+                </div>
+                <div className="box-footer flex justify-end space-x-2">
+                    <button onClick={() => router.back()} className="btn btn-default">Cancel</button>
+                    <button onClick={handleDelete} className="btn btn-danger">Delete</button>
+                </div>
+            </div>
+        </Layout>
+    );
+}

--- a/frontend/src/app/currencies/[code]/edit/page.tsx
+++ b/frontend/src/app/currencies/[code]/edit/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+import {useRouter, useParams} from 'next/navigation';
+import Layout from '../../../../components/Layout';
+
+export default function EditCurrency() {
+    const router = useRouter();
+    const params = useParams();
+    const code = params?.code as string;
+    const [form, setForm] = useState({name: '', symbol: '', code: '', decimal_places: 2});
+    const [defaultCode, setDefaultCode] = useState('');
+    const [rate, setRate] = useState<number|null>(null);
+
+    useEffect(() => {
+        async function load() {
+            if (!code) {return;}
+            const [defRes, curRes] = await Promise.all([
+                fetch('/api/v1/currencies/default'),
+                fetch(`/api/v1/currencies/${code}`)
+            ]);
+            if (defRes.ok) {
+                const defJson = await defRes.json();
+                setDefaultCode(defJson.data.attributes.code);
+            }
+            if (curRes.ok) {
+                const curJson = await curRes.json();
+                const attrs = curJson.data.attributes;
+                setForm({name: attrs.name, symbol: attrs.symbol, code: attrs.code, decimal_places: attrs.decimal_places});
+            }
+            if (defaultCode) {
+                const rRes = await fetch(`/api/v1/exchange-rates/rates/${code}/${defaultCode}`);
+                if (rRes.ok) {
+                    const rJson = await rRes.json();
+                    setRate(rJson.data?.[0]?.attributes?.rate ?? null);
+                }
+            }
+        }
+        load();
+    }, [code, defaultCode]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setForm({...form, [e.target.name]: e.target.value});
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        await fetch(`/api/v1/currencies/${code}`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({data: {attributes: form}})
+        });
+        router.push('/currencies');
+    };
+
+    return (
+        <Layout title={`Edit ${code}`}>
+            <form onSubmit={handleSubmit} className="form-horizontal">
+                <div className="box box-primary">
+                    <div className="box-body space-y-2">
+                        <input name="name" value={form.name} onChange={handleChange} className="form-control" />
+                        <input name="symbol" value={form.symbol} onChange={handleChange} className="form-control" />
+                        <input name="code" value={form.code} onChange={handleChange} className="form-control" />
+                        <input name="decimal_places" type="number" value={form.decimal_places} onChange={handleChange} className="form-control" />
+                        <p>Exchange rate vs {defaultCode}: {rate ?? 'N/A'}</p>
+                    </div>
+                    <div className="box-footer">
+                        <button type="submit" className="btn btn-success pull-right">Update currency</button>
+                    </div>
+                </div>
+            </form>
+        </Layout>
+    );
+}

--- a/frontend/src/app/currencies/create/page.tsx
+++ b/frontend/src/app/currencies/create/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {useState} from 'react';
+import {useRouter} from 'next/navigation';
+import Layout from '../../../components/Layout';
+
+export default function CreateCurrency() {
+    const router = useRouter();
+    const [form, setForm] = useState({name: '', symbol: '', code: '', decimal_places: 2});
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setForm({...form, [e.target.name]: e.target.value});
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            await fetch('/api/v1/currencies', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({data: {attributes: form}})
+            });
+            router.push('/currencies');
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    return (
+        <Layout title="Create currency">
+            <form onSubmit={handleSubmit} className="form-horizontal">
+                <div className="box box-primary">
+                    <div className="box-body space-y-2">
+                        <input name="name" value={form.name} onChange={handleChange} placeholder="Name" className="form-control" />
+                        <input name="symbol" value={form.symbol} onChange={handleChange} placeholder="Symbol" className="form-control" />
+                        <input name="code" value={form.code} onChange={handleChange} placeholder="Code" className="form-control" />
+                        <input name="decimal_places" type="number" value={form.decimal_places} onChange={handleChange} className="form-control" />
+                    </div>
+                    <div className="box-footer">
+                        <button type="submit" className="btn btn-success pull-right">Store currency</button>
+                    </div>
+                </div>
+            </form>
+        </Layout>
+    );
+}

--- a/frontend/src/app/currencies/page.tsx
+++ b/frontend/src/app/currencies/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+
+interface Currency {
+    id: number;
+    code: string;
+    name: string;
+    symbol: string;
+    decimal_places: number;
+}
+
+interface ApiCurrency {
+    id: string;
+    attributes: {
+        code: string;
+        name: string;
+        symbol: string;
+        decimal_places: number;
+    };
+}
+
+export default function CurrencyIndex() {
+    const [currencies, setCurrencies] = useState<Currency[]>([]);
+    const [defaultCode, setDefaultCode] = useState<string>('');
+    const [rates, setRates] = useState<Record<string, number>>({});
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const [defRes, curRes] = await Promise.all([
+                    fetch('/api/v1/currencies/default'),
+                    fetch('/api/v1/currencies')
+                ]);
+                if (defRes.ok) {
+                    const defJson = await defRes.json();
+                    setDefaultCode(defJson.data.attributes.code);
+                }
+                if (curRes.ok) {
+                    const curJson = await curRes.json();
+                    const list: Currency[] = (curJson.data as ApiCurrency[]).map((c) => ({
+                        id: parseInt(c.id, 10),
+                        code: c.attributes.code,
+                        name: c.attributes.name,
+                        symbol: c.attributes.symbol,
+                        decimal_places: c.attributes.decimal_places
+                    }));
+                    setCurrencies(list);
+                    // fetch exchange rates for each currency vs default
+                    const ratePromises = list.map(async (c) => {
+                        if (!defaultCode || c.code === defaultCode) {
+                            return [c.code, 1];
+                        }
+                        try {
+                            const r = await fetch(`/api/v1/exchange-rates/rates/${c.code}/${defaultCode}`);
+                            if (r.ok) {
+                                const rJson = await r.json();
+                                const rate = rJson.data?.[0]?.attributes?.rate;
+                                return [c.code, rate ?? null];
+                            }
+                        } catch (e) {
+                            console.error(e);
+                        }
+                        return [c.code, null];
+                    });
+                    const results = await Promise.all(ratePromises);
+                    const rateMap: Record<string, number> = {};
+                    results.forEach(([code, rate]) => {
+                        if (rate !== null) {
+                            rateMap[code as string] = rate as number;
+                        }
+                    });
+                    setRates(rateMap);
+                }
+            } catch (e) {
+                console.error(e);
+            }
+        }
+        load();
+    }, [defaultCode]);
+
+    return (
+        <Layout title="Currencies">
+            <div className="box">
+                <div className="box-header with-border flex justify-between items-center">
+                    <h3 className="box-title">Currencies</h3>
+                    <Link href="/currencies/create" className="btn btn-success">Create currency</Link>
+                </div>
+                <div className="box-body">
+                    <table className="table table-hover">
+                        <thead>
+                        <tr>
+                            <th>Code</th>
+                            <th>Name</th>
+                            <th>Decimals</th>
+                            <th>Exchange rate vs {defaultCode}</th>
+                            <th></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {currencies.map(c => (
+                            <tr key={c.id}>
+                                <td>{c.code}</td>
+                                <td>{c.name} ({c.symbol})</td>
+                                <td>{c.decimal_places}</td>
+                                <td>{rates[c.code] ?? 'N/A'}</td>
+                                <td>
+                                    <Link href={`/currencies/${c.code}/edit`} className="btn btn-xs btn-default mr-2">Edit</Link>
+                                    <Link href={`/currencies/${c.code}/delete`} className="btn btn-xs btn-danger">Delete</Link>
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </Layout>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add Next.js currency list, create, edit and delete pages
- fetch live exchange rates from backend API for currency views

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'tailwindcss' or its types)*

------
https://chatgpt.com/codex/tasks/task_b_689dfb723dc88332b13b86773e0580f0