### PR TITLE
feat: add transactions pages

### DIFF
--- a/frontend/src/app/transactions/[id]/convert/page.tsx
+++ b/frontend/src/app/transactions/[id]/convert/page.tsx
@@ -1,0 +1,39 @@
+import { useState, FormEvent } from "react";
+import Layout from "@/components/Layout";
+
+interface Props {
+    params: { id: string };
+}
+
+export default function ConvertTransactionPage({ params }: Props) {
+    const [type, setType] = useState("");
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        await fetch(`/api/transactions/${params.id}/convert`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ type }),
+        });
+    };
+
+    return (
+        <Layout title="Convert Transaction">
+            <h1 className="text-2xl mb-4">Convert Transaction</h1>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label htmlFor="type" className="block">Type</label>
+                    <input
+                        id="type"
+                        value={type}
+                        onChange={(e) => setType(e.target.value)}
+                        className="border p-2 w-full"
+                    />
+                </div>
+                <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+                    Convert
+                </button>
+            </form>
+        </Layout>
+    );
+}

--- a/frontend/src/app/transactions/[id]/delete/page.tsx
+++ b/frontend/src/app/transactions/[id]/delete/page.tsx
@@ -1,0 +1,27 @@
+import Layout from "@/components/Layout";
+import { useRouter } from "next/navigation";
+
+interface Props {
+    params: { id: string };
+}
+
+export default function DeleteTransactionPage({ params }: Props) {
+    const router = useRouter();
+
+    const handleDelete = async () => {
+        await fetch(`/api/transactions/${params.id}`, { method: "DELETE" });
+        router.push("/transactions");
+    };
+
+    return (
+        <Layout title="Delete Transaction">
+            <h1 className="text-2xl mb-4">Delete Transaction</h1>
+            <button
+                onClick={handleDelete}
+                className="bg-red-500 text-white px-4 py-2"
+            >
+                Confirm Delete
+            </button>
+        </Layout>
+    );
+}

--- a/frontend/src/app/transactions/[id]/edit/page.tsx
+++ b/frontend/src/app/transactions/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import TransactionForm, { TransactionData } from "@/components/TransactionForm";
+
+interface Props {
+    params: { id: string };
+}
+
+export default function EditTransactionPage({ params }: Props) {
+    const [transaction, setTransaction] = useState<TransactionData | null>(null);
+
+    useEffect(() => {
+        fetch(`/api/transactions/${params.id}`)
+            .then((res) => res.json())
+            .then((data) => setTransaction(data.data))
+            .catch(() => setTransaction(null));
+    }, [params.id]);
+
+    const handleSubmit = async (data: TransactionData) => {
+        await fetch(`/api/transactions/${params.id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+    };
+
+    if (!transaction) {
+        return (
+            <Layout title="Edit Transaction">
+                <p>Loading...</p>
+            </Layout>
+        );
+    }
+
+    return (
+        <Layout title="Edit Transaction">
+            <h1 className="text-2xl mb-4">Edit Transaction</h1>
+            <TransactionForm initialData={transaction} onSubmit={handleSubmit} />
+        </Layout>
+    );
+}

--- a/frontend/src/app/transactions/[id]/page.tsx
+++ b/frontend/src/app/transactions/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Layout from "@/components/Layout";
+import { TransactionData } from "@/components/TransactionForm";
+
+interface Props {
+    params: { id: string };
+}
+
+export default function ShowTransactionPage({ params }: Props) {
+    const [transaction, setTransaction] = useState<TransactionData | null>(null);
+
+    useEffect(() => {
+        fetch(`/api/transactions/${params.id}`)
+            .then((res) => res.json())
+            .then((data) => setTransaction(data.data))
+            .catch(() => setTransaction(null));
+    }, [params.id]);
+
+    if (!transaction) {
+        return (
+            <Layout title="Transaction">
+                <p>Loading...</p>
+            </Layout>
+        );
+    }
+
+    return (
+        <Layout title="Transaction">
+            <h1 className="text-2xl mb-4">{transaction.description}</h1>
+            <p className="mb-4">Amount: {transaction.amount}</p>
+            <Link
+                href={`/transactions/${params.id}/edit`}
+                className="text-blue-500 underline"
+            >
+                Edit
+            </Link>
+        </Layout>
+    );
+}

--- a/frontend/src/app/transactions/create/page.tsx
+++ b/frontend/src/app/transactions/create/page.tsx
@@ -1,0 +1,19 @@
+import Layout from "@/components/Layout";
+import TransactionForm, { TransactionData } from "@/components/TransactionForm";
+
+export default function CreateTransactionPage() {
+    const handleSubmit = async (data: TransactionData) => {
+        await fetch("/api/transactions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+        });
+    };
+
+    return (
+        <Layout title="Create Transaction">
+            <h1 className="text-2xl mb-4">Create Transaction</h1>
+            <TransactionForm onSubmit={handleSubmit} />
+        </Layout>
+    );
+}

--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+
+interface Transaction {
+    id: string;
+    description: string;
+    amount: number;
+}
+
+export default function TransactionsPage() {
+    const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+    useEffect(() => {
+        fetch("/api/transactions")
+            .then((res) => res.json())
+            .then((data) => setTransactions(data.data || []))
+            .catch(() => setTransactions([]));
+    }, []);
+
+    return (
+        <Layout title="Transactions">
+            <h1 className="text-2xl mb-4">Transactions</h1>
+            <Link href="/transactions/create" className="text-blue-500 underline">
+                Create Transaction
+            </Link>
+            <ul className="mt-4 space-y-2">
+                {transactions.map((t) => (
+                    <li key={t.id}>
+                        <Link href={`/transactions/${t.id}`} className="text-blue-600">
+                            {t.description} - {t.amount}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </Layout>
+    );
+}
+

--- a/frontend/src/components/TransactionForm.tsx
+++ b/frontend/src/components/TransactionForm.tsx
@@ -1,0 +1,48 @@
+import { FormEvent, useState } from "react";
+
+export interface TransactionData {
+    description: string;
+    amount: number;
+}
+
+interface Props {
+    initialData?: Partial<TransactionData>;
+    onSubmit: (data: TransactionData) => Promise<void>;
+}
+
+export default function TransactionForm({ initialData = {}, onSubmit }: Props) {
+    const [description, setDescription] = useState(initialData.description || "");
+    const [amount, setAmount] = useState<number>(initialData.amount ?? 0);
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        await onSubmit({ description, amount });
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+                <label htmlFor="description" className="block">Description</label>
+                <input
+                    id="description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    className="border p-2 w-full"
+                />
+            </div>
+            <div>
+                <label htmlFor="amount" className="block">Amount</label>
+                <input
+                    id="amount"
+                    type="number"
+                    value={amount}
+                    onChange={(e) => setAmount(parseFloat(e.target.value))}
+                    className="border p-2 w-full"
+                />
+            </div>
+            <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+                Submit
+            </button>
+        </form>
+    );
+}


### PR DESCRIPTION
## Summary
- add React pages for transactions listing, details, and actions
- implement reusable TransactionForm component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689dfb80aa0c8332bbb0636dfbe17cae