### PR TITLE
Add React components for rule management UI

### DIFF
--- a/frontend/src/app/rules/[id]/edit/page.tsx
+++ b/frontend/src/app/rules/[id]/edit/page.tsx
@@ -1,0 +1,21 @@
+import RuleForm, {RuleData} from '@/components/rules/RuleForm';
+
+export default function EditRulePage() {
+    const initial: RuleData = {
+        title: 'Sample rule',
+        description: 'Example description',
+        triggers: [
+            {type: 'description_is', prohibited: false, value: 'Test', stopProcessing: false},
+        ],
+        actions: [
+            {type: 'set_category', value: 'Sample', stopProcessing: false},
+        ],
+    };
+
+    return (
+        <div className="p-4">
+            <h1 className="text-2xl mb-4">Edit Rule</h1>
+            <RuleForm initial={initial} />
+        </div>
+    );
+}

--- a/frontend/src/app/rules/create/page.tsx
+++ b/frontend/src/app/rules/create/page.tsx
@@ -1,0 +1,10 @@
+import RuleForm from '@/components/rules/RuleForm';
+
+export default function CreateRulePage() {
+    return (
+        <div className="p-4">
+            <h1 className="text-2xl mb-4">Create Rule</h1>
+            <RuleForm />
+        </div>
+    );
+}

--- a/frontend/src/app/rules/page.tsx
+++ b/frontend/src/app/rules/page.tsx
@@ -1,0 +1,16 @@
+import RuleList, {RuleGroup} from '@/components/rules/RuleList';
+
+const sample: RuleGroup[] = [
+    {id: 1, title: 'Default group', description: 'Example rule group', rules: [
+        {id: 1, title: 'Sample rule'},
+    ]},
+];
+
+export default function RulesPage() {
+    return (
+        <div className="p-4">
+            <h1 className="text-2xl mb-4">Rules</h1>
+            <RuleList groups={sample} />
+        </div>
+    );
+}

--- a/frontend/src/components/rules/RuleAction.tsx
+++ b/frontend/src/components/rules/RuleAction.tsx
@@ -1,0 +1,62 @@
+'use client';
+import React from 'react';
+
+export interface RuleAction {
+    type: string;
+    value: string;
+    stopProcessing: boolean;
+}
+
+interface Props {
+    index: number;
+    action: RuleAction;
+    actionOptions: Record<string, string>;
+    onChange: (index: number, action: RuleAction) => void;
+    onRemove: (index: number) => void;
+}
+
+export default function RuleActionRow({index, action, actionOptions, onChange, onRemove}: Props) {
+    const handle = (field: keyof RuleAction, value: string | boolean) => {
+        onChange(index, {...action, [field]: value});
+    };
+
+    return (
+        <tr>
+            <td>
+                <button
+                    type="button"
+                    className="btn btn-danger btn-sm"
+                    onClick={() => onRemove(index)}
+                >
+                    <span className="fa fa-trash" />
+                </button>
+            </td>
+            <td>
+                <select
+                    className="form-control"
+                    value={action.type}
+                    onChange={e => handle('type', e.target.value)}
+                >
+                    {Object.entries(actionOptions).map(([key, label]) => (
+                        <option key={key} value={key}>{label}</option>
+                    ))}
+                </select>
+            </td>
+            <td>
+                <input
+                    type="text"
+                    className="form-control"
+                    value={action.value}
+                    onChange={e => handle('value', e.target.value)}
+                />
+            </td>
+            <td>
+                <input
+                    type="checkbox"
+                    checked={action.stopProcessing}
+                    onChange={e => handle('stopProcessing', e.target.checked)}
+                />
+            </td>
+        </tr>
+    );
+}

--- a/frontend/src/components/rules/RuleForm.tsx
+++ b/frontend/src/components/rules/RuleForm.tsx
@@ -1,0 +1,115 @@
+'use client';
+import React, {useState} from 'react';
+import RuleTriggerRow, {RuleTrigger} from './RuleTrigger';
+import RuleActionRow, {RuleAction} from './RuleAction';
+
+export interface RuleData {
+    title: string;
+    description: string;
+    triggers: RuleTrigger[];
+    actions: RuleAction[];
+}
+
+const triggerOptions: Record<string, string> = {
+    description_is: 'Description is',
+    amount_gt: 'Amount greater than',
+};
+
+const actionOptions: Record<string, string> = {
+    set_category: 'Set category',
+    set_budget: 'Set budget',
+};
+
+export default function RuleForm({initial}: {initial?: RuleData}) {
+    const [title, setTitle] = useState(initial?.title ?? '');
+    const [description, setDescription] = useState(initial?.description ?? '');
+    const [triggers, setTriggers] = useState<RuleTrigger[]>(initial?.triggers ?? [
+        {type: 'description_is', prohibited: false, value: '', stopProcessing: false},
+    ]);
+    const [actions, setActions] = useState<RuleAction[]>(initial?.actions ?? [
+        {type: 'set_category', value: '', stopProcessing: false},
+    ]);
+
+    const updateTrigger = (index: number, trigger: RuleTrigger) => {
+        setTriggers(triggers.map((t, i) => (i === index ? trigger : t)));
+    };
+    const removeTrigger = (index: number) => {
+        setTriggers(triggers.filter((_, i) => i !== index));
+    };
+    const addTrigger = () => {
+        setTriggers([...triggers, {type: 'description_is', prohibited: false, value: '', stopProcessing: false}]);
+    };
+
+    const updateAction = (index: number, action: RuleAction) => {
+        setActions(actions.map((a, i) => (i === index ? action : a)));
+    };
+    const removeAction = (index: number) => {
+        setActions(actions.filter((_, i) => i !== index));
+    };
+    const addAction = () => {
+        setActions([...actions, {type: 'set_category', value: '', stopProcessing: false}]);
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const result: RuleData = {title, description, triggers, actions};
+        // For now just log the result
+        console.log(result);
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+                <label className="block">Title</label>
+                <input className="form-control" value={title} onChange={e => setTitle(e.target.value)} />
+            </div>
+            <div>
+                <label className="block">Description</label>
+                <input className="form-control" value={description} onChange={e => setDescription(e.target.value)} />
+            </div>
+            <div>
+                <h3>Triggers</h3>
+                <table className="table">
+                    <tbody>
+                    {triggers.map((trigger, index) => (
+                        <RuleTriggerRow
+                            key={index}
+                            index={index}
+                            trigger={trigger}
+                            triggerOptions={triggerOptions}
+                            onChange={updateTrigger}
+                            onRemove={removeTrigger}
+                        />
+                    ))}
+                    </tbody>
+                </table>
+                <button type="button" className="btn btn-default" onClick={addTrigger}>
+                    Add trigger
+                </button>
+            </div>
+            <div>
+                <h3>Actions</h3>
+                <table className="table">
+                    <tbody>
+                    {actions.map((action, index) => (
+                        <RuleActionRow
+                            key={index}
+                            index={index}
+                            action={action}
+                            actionOptions={actionOptions}
+                            onChange={updateAction}
+                            onRemove={removeAction}
+                        />
+                    ))}
+                    </tbody>
+                </table>
+                <button type="button" className="btn btn-default" onClick={addAction}>
+                    Add action
+                </button>
+            </div>
+            <div>
+                <button type="submit" className="btn btn-primary">Save rule</button>
+            </div>
+        </form>
+    );
+}

--- a/frontend/src/components/rules/RuleList.tsx
+++ b/frontend/src/components/rules/RuleList.tsx
@@ -1,0 +1,37 @@
+'use client';
+import React from 'react';
+
+export interface Rule {
+    id: number;
+    title: string;
+    description?: string;
+}
+
+export interface RuleGroup {
+    id: number;
+    title: string;
+    description?: string;
+    rules: Rule[];
+}
+
+export default function RuleList({groups}: {groups: RuleGroup[]}) {
+    return (
+        <div className="space-y-6">
+            {groups.map(group => (
+                <div key={group.id} className="border p-4 rounded">
+                    <h2 className="text-xl font-bold">{group.title}</h2>
+                    {group.description && <p className="mb-2">{group.description}</p>}
+                    {group.rules.length > 0 ? (
+                        <ul className="list-disc ml-6">
+                            {group.rules.map(rule => (
+                                <li key={rule.id}>{rule.title}</li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p><em>No rules</em></p>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/components/rules/RuleTrigger.tsx
+++ b/frontend/src/components/rules/RuleTrigger.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React from 'react';
+
+export interface RuleTrigger {
+    type: string;
+    prohibited: boolean;
+    value: string;
+    stopProcessing: boolean;
+}
+
+interface Props {
+    index: number;
+    trigger: RuleTrigger;
+    triggerOptions: Record<string, string>;
+    onChange: (index: number, trigger: RuleTrigger) => void;
+    onRemove: (index: number) => void;
+}
+
+export default function RuleTriggerRow({index, trigger, triggerOptions, onChange, onRemove}: Props) {
+    const handle = (field: keyof RuleTrigger, value: string | boolean) => {
+        onChange(index, {...trigger, [field]: value});
+    };
+
+    return (
+        <tr>
+            <td>
+                <button
+                    type="button"
+                    className="btn btn-danger btn-sm"
+                    onClick={() => onRemove(index)}
+                >
+                    <span className="fa fa-trash" />
+                </button>
+            </td>
+            <td>
+                <select
+                    className="form-control"
+                    value={trigger.type}
+                    onChange={e => handle('type', e.target.value)}
+                >
+                    {Object.entries(triggerOptions).map(([key, label]) => (
+                        <option key={key} value={key}>{label}</option>
+                    ))}
+                </select>
+            </td>
+            <td>
+                <input
+                    type="checkbox"
+                    checked={trigger.prohibited}
+                    onChange={e => handle('prohibited', e.target.checked)}
+                />
+            </td>
+            <td>
+                <input
+                    type="text"
+                    className="form-control"
+                    value={trigger.value}
+                    onChange={e => handle('value', e.target.value)}
+                />
+            </td>
+            <td>
+                <input
+                    type="checkbox"
+                    checked={trigger.stopProcessing}
+                    onChange={e => handle('stopProcessing', e.target.checked)}
+                />
+            </td>
+        </tr>
+    );
+}


### PR DESCRIPTION
## Summary
- add reusable React components to manage rule triggers and actions
- introduce Next.js pages for listing, creating and editing rules

## Testing
- `cd frontend && npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689dfba3cd108332a936f9f55acd30a3