### PR TITLE
feat: add modular react utilities

### DIFF
--- a/frontend/src/components/ItemList.tsx
+++ b/frontend/src/components/ItemList.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from '../styles/ItemList.module.css';
+
+export interface ItemListProps<T> {
+  items: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+}
+
+export function ItemList<T>({ items, renderItem }: ItemListProps<T>) {
+  return (
+    <ul className={styles.list}>
+      {items.map((item, idx) => (
+        <li key={idx} className={styles.item}>
+          {renderItem(item, idx)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default ItemList;

--- a/frontend/src/components/Message.tsx
+++ b/frontend/src/components/Message.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styles from '../styles/Message.module.css';
+
+export interface MessageProps {
+  type: 'success' | 'error' | 'info';
+  text: string;
+}
+
+export const Message: React.FC<MessageProps> = ({ type, text }) => (
+  <div className={`${styles.message} ${styles[type]}`}>
+    {text}
+  </div>
+);
+
+export default Message;

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from '../styles/Pagination.module.css';
+
+export interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+}
+
+export const Pagination: React.FC<PaginationProps> = ({ page, totalPages, onChange }) => {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  return (
+    <nav className={styles.pagination}>
+      {pages.map(p => (
+        <span
+          key={p}
+          className={`${styles.page} ${p === page ? styles.active : ''}`}
+          onClick={() => onChange(p)}
+        >
+          {p}
+        </span>
+      ))}
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/frontend/src/components/Popup.tsx
+++ b/frontend/src/components/Popup.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from '../styles/Popup.module.css';
+
+export interface PopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export const Popup: React.FC<PopupProps> = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.content} onClick={e => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Popup;

--- a/frontend/src/styles/ItemList.module.css
+++ b/frontend/src/styles/ItemList.module.css
@@ -1,0 +1,2 @@
+.list { list-style: none; padding: 0; margin: 0; }
+.item { padding: 0.5rem; border-bottom: 1px solid #eee; }

--- a/frontend/src/styles/Message.module.css
+++ b/frontend/src/styles/Message.module.css
@@ -1,0 +1,4 @@
+.message { padding: 1rem; border-radius: 0.25rem; }
+.success { background-color: #d4edda; color: #155724; }
+.error { background-color: #f8d7da; color: #721c24; }
+.info { background-color: #d1ecf1; color: #0c5460; }

--- a/frontend/src/styles/Pagination.module.css
+++ b/frontend/src/styles/Pagination.module.css
@@ -1,0 +1,3 @@
+.pagination { display:flex; gap:0.5rem; }
+.page { padding:0.5rem 0.75rem; border:1px solid #ccc; cursor:pointer; }
+.active { background:#007bff; color:white; }

--- a/frontend/src/styles/Popup.module.css
+++ b/frontend/src/styles/Popup.module.css
@@ -1,0 +1,2 @@
+.overlay { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
+.content { background:white; padding:1rem; border-radius:0.25rem; min-width:300px; }

--- a/frontend/src/utils/useFetchJson.ts
+++ b/frontend/src/utils/useFetchJson.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useFetchJson<T = unknown>(url: string): T | null {
+  const [data, setData] = useState<T | null>(null);
+
+  useEffect(() => {
+    fetch(url)
+      .then(res => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, [url]);
+
+  return data;
+}

--- a/frontend/src/utils/useForm.ts
+++ b/frontend/src/utils/useForm.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export interface FormHandlers<T> {
+  values: T;
+  handleChange: (field: keyof T, value: T[keyof T]) => void;
+  reset: () => void;
+}
+
+export function useForm<T extends Record<string, unknown>>(initialValues: T): FormHandlers<T> {
+  const [values, setValues] = useState<T>(initialValues);
+
+  function handleChange(field: keyof T, value: T[keyof T]) {
+    setValues(prev => ({ ...prev, [field]: value }));
+  }
+
+  function reset() {
+    setValues(initialValues);
+  }
+
+  return { values, handleChange, reset };
+}

--- a/frontend/src/utils/usePopup.ts
+++ b/frontend/src/utils/usePopup.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export interface PopupControls {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+export function usePopup(initialState = false): PopupControls {
+  const [isOpen, setOpen] = useState(initialState);
+
+  return {
+    isOpen,
+    open: () => setOpen(true),
+    close: () => setOpen(false),
+    toggle: () => setOpen(prev => !prev)
+  };
+}

--- a/frontend/src/utils/useScriptVariables.ts
+++ b/frontend/src/utils/useScriptVariables.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function useScriptVariables<T = unknown>(modulePath: string): T | null {
+  const [vars, setVars] = useState<T | null>(null);
+
+  useEffect(() => {
+    import(modulePath).then((mod) => {
+      const value = mod as { default?: T } | T;
+      setVars('default' in value ? value.default! : value);
+    });
+  }, [modulePath]);
+
+  return vars;
+}


### PR DESCRIPTION
## Summary
- add typed Message component with style modules
- introduce generic ItemList, Popup, and Pagination components
- provide hooks for forms, popups, script variables, and JSON fetching

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_689dfb68f9cc8332a0af8c1c4dc5c382