### PR TITLE
feat(frontend): add React equivalents for Twig partials

### DIFF
--- a/frontend/src/components/partials/Empty.tsx
+++ b/frontend/src/components/partials/Empty.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+export interface EmptyProps {
+  type: string;
+  objectType: string;
+  route: string;
+  jsNonce?: string;
+  translate?: (key: string) => string;
+}
+
+const defaultTranslate = (key: string) => key;
+
+const Empty: React.FC<EmptyProps> = ({
+  type,
+  objectType,
+  route,
+  jsNonce,
+  translate = defaultTranslate,
+}) => {
+  const key = (suffix: string) => translate(`no_${type}_${suffix}_${objectType}`);
+  return (
+    <div className="row">
+      <div className="col-lg-6 col-md-6 col-sm-12 col-xs-12 col-lg-offset-3 col-md-offset-3">
+        <div className="box box-success">
+          <div className="box-header with-border">
+            <h3 className="box-title">{key("title")}</h3>
+          </div>
+          <div className="box-body">
+            <p>{key("intro")}</p>
+            <p>{key("imperative")}</p>
+            <p style={{ textAlign: "center" }}>
+              <a className="btn btn-lg btn-success" href={route}>
+                {key("create")}
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+      {jsNonce && (
+        <script type="text/javascript" nonce={jsNonce}>
+          {"forceDemoOff = true;"}
+        </script>
+      )}
+    </div>
+  );
+};
+
+export default Empty;

--- a/frontend/src/components/partials/Favicons.tsx
+++ b/frontend/src/components/partials/Favicons.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Head from "next/head";
+
+const Favicons: React.FC = () => (
+  <Head>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="favicon-32x32.png?v=3e8AboOwbd"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="favicon-16x16.png?v=3e8AboOwbd"
+    />
+    <link
+      rel="manifest"
+      href="manifest.webmanifest?v=3e8AboOwbd"
+      crossOrigin="use-credentials"
+    />
+    <link rel="mask-icon" href="safari-pinned-tab.svg" color="#3c8dbc" />
+    <link rel="shortcut icon" href="favicon.ico?v=3e8AboOwbd" />
+    <meta name="apple-mobile-web-app-title" content="Firefly III" />
+    <meta name="application-name" content="Firefly III" />
+    <meta name="msapplication-TileColor" content="#3c8dbc" />
+    <meta name="msapplication-TileImage" content="mstile-144x144.png?v=3e8AboOwbd" />
+    <meta name="theme-color" content="#3c8dbc" />
+  </Head>
+);
+
+export default Favicons;


### PR DESCRIPTION
## Summary
- add React `Empty` component mirroring empty.twig variables
- add React `Favicons` component for head icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689dfb67e26883328523111910d863bb