### PR TITLE
feat(frontend): add React layouts

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import Layout from "../components/Layout";
+import LayoutDefault from "../components/LayoutDefault";
 
 export default function Home() {
     return (
-        <Layout title="Home">
+        <LayoutDefault title="Home">
             <div className="font-sans min-h-screen flex flex-col items-center justify-center p-8">
                 <main className="text-center space-y-4">
                     <h1 className="text-4xl font-bold">Welcome to Firefly III</h1>
@@ -21,6 +21,6 @@ export default function Home() {
                     </p>
                 </main>
             </div>
-        </Layout>
+        </LayoutDefault>
     );
 }

--- a/frontend/src/components/LayoutDefault.tsx
+++ b/frontend/src/components/LayoutDefault.tsx
@@ -2,12 +2,15 @@ import Head from "next/head";
 import Link from "next/link";
 import React, { ReactNode } from "react";
 
-interface LayoutProps {
+interface LayoutDefaultProps {
     children: ReactNode;
     title?: string;
+    styles?: ReactNode;
+    definitions?: ReactNode;
+    scripts?: ReactNode;
 }
 
-export default function Layout({children, title}: LayoutProps) {
+export default function LayoutDefault({children, title, styles, definitions, scripts}: LayoutDefaultProps) {
     const pageTitle = title ? `${title} » Firefly III` : "Firefly III";
     return (
         <>
@@ -15,6 +18,8 @@ export default function Layout({children, title}: LayoutProps) {
                 <title>{pageTitle}</title>
                 <meta charSet="UTF-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
+                {styles}
+                {definitions}
             </Head>
             <div className="wrapper" id="app">
                 <header className="main-header">
@@ -34,6 +39,7 @@ export default function Layout({children, title}: LayoutProps) {
                     <strong><a href="https://github.com/firefly-iii/firefly-iii">Firefly III</a></strong>
                 </footer>
             </div>
+            {scripts}
         </>
     );
 }

--- a/frontend/src/components/LayoutEmpty.tsx
+++ b/frontend/src/components/LayoutEmpty.tsx
@@ -1,0 +1,29 @@
+import Head from "next/head";
+import Link from "next/link";
+import React, { ReactNode } from "react";
+
+interface LayoutEmptyProps {
+    children: ReactNode;
+    title?: string;
+}
+
+export default function LayoutEmpty({children, title}: LayoutEmptyProps) {
+    const pageTitle = title ? `${title} » Firefly III` : "Firefly III";
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <div className="login-box">
+                <div className="login-logo">
+                    <Link href="/">
+                        <strong>Firefly</strong>III
+                    </Link>
+                </div>
+                {children}
+            </div>
+        </>
+    );
+}

--- a/frontend/src/components/LayoutGuest.tsx
+++ b/frontend/src/components/LayoutGuest.tsx
@@ -1,0 +1,36 @@
+import Head from "next/head";
+import Link from "next/link";
+import React, { ReactNode } from "react";
+
+interface LayoutGuestProps {
+    children: ReactNode;
+    title?: string;
+    scripts?: ReactNode;
+}
+
+export default function LayoutGuest({children, title, scripts}: LayoutGuestProps) {
+    const pageTitle = title ? `${title} » Firefly III` : "Firefly III";
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <div className="login-box">
+                <div className="login-logo">
+                    <Link href="/">
+                        <strong>Firefly</strong>III
+                    </Link>
+                </div>
+                {children}
+            </div>
+            <div className="text-center text-muted">
+                <small>
+                    Developed by James Cole, the source code is licensed under the <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0-or-later</a>.
+                </small>
+            </div>
+            {scripts}
+        </>
+    );
+}

--- a/frontend/src/components/LayoutInstall.tsx
+++ b/frontend/src/components/LayoutInstall.tsx
@@ -1,0 +1,34 @@
+import Head from "next/head";
+import React, { ReactNode } from "react";
+
+interface LayoutInstallProps {
+    children: ReactNode;
+    title?: string;
+    scripts?: ReactNode;
+}
+
+export default function LayoutInstall({children, title, scripts}: LayoutInstallProps) {
+    const pageTitle = title ? `${title} » Firefly III` : "Firefly III - Installation and update";
+    return (
+        <>
+            <Head>
+                <title>{pageTitle}</title>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <div className="login-box">
+                <div className="login-logo">
+                    <strong>Firefly</strong>III<br/>
+                    <span style={{fontFamily: "monospace", fontSize: "16pt"}}>installation and upgrade</span>
+                </div>
+                {children}
+            </div>
+            <div className="text-center text-muted">
+                <small>
+                    Developed by James Cole, the source code is licensed under the <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0-or-later</a>.
+                </small>
+            </div>
+            {scripts}
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- convert legacy Twig layouts into reusable React components
- support named slots via props for styles, scripts, and definitions
- wire home page to new default layout wrapper

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689dfb65ac6483328f39a316ca5a9c46