### PR TITLE
Port object group views to handle accounts and categories

### DIFF
--- a/resources/views/object-groups/delete.twig
+++ b/resources/views/object-groups/delete.twig
@@ -23,12 +23,6 @@
                             {{ trans('form.object_group_areYouSure', {'title': objectGroup.title}) }}
                         </p>
 
-                        {% if piggyBanks > 0 %}
-                            <p>
-                                {{ Lang.choice('form.not_delete_piggy_banks', piggyBanks, {count: piggyBanks}) }}
-                            </p>
-                        {% endif %}
-
                     </div>
                     <div class="box-footer">
                         <input type="submit" name="submit" value="{{ trans('form.deletePermanently') }}" class="btn pull-right btn-danger"/>

--- a/resources/views/object-groups/edit.twig
+++ b/resources/views/object-groups/edit.twig
@@ -50,8 +50,6 @@
     <script type="text/javascript" src="v1/js/lib/modernizr-custom.js?v={{ FF_VERSION }}"
             nonce="{{ JS_NONCE }}"></script>
     <script type="text/javascript" src="v1/js/lib/jquery-ui.min.js?v={{ FF_VERSION }}" nonce="{{ JS_NONCE }}"></script>
-    <script type="text/javascript" src="v1/js/ff/piggy-banks/create.js?v={{ FF_VERSION }}"
-            nonce="{{ JS_NONCE }}"></script>
     {# auto complete for object groups #}
     <script type="text/javascript" src="v1/js/lib/typeahead/typeahead.bundle.min.js?v={{ FF_VERSION }}"
             nonce="{{ JS_NONCE }}"></script>

--- a/resources/views/object-groups/index.twig
+++ b/resources/views/object-groups/index.twig
@@ -42,11 +42,11 @@
                                     <td>
                                         <strong>{{ objectGroup.title }}</strong><br/>
 
-                                        {% for piggyBank in objectGroup.piggyBanks %}
-                                            - {{ 'piggy_bank'|_ }}: <a href="{{ route('piggy-banks.show', [piggyBank.id]) }}">{{ piggyBank.name }}</a><br>
+                                        {% for account in objectGroup.accounts %}
+                                            - {{ 'account'|_ }}: <a href="{{ route('accounts.show', [account.id]) }}">{{ account.name }}</a><br>
                                         {% endfor %}
-                                        {% for bill in objectGroup.bills %}
-                                            - {{ 'bill'|_ }}: <a href="{{ route('subscriptions.show', [bill.id]) }}">{{ bill.name }}</a><br>
+                                        {% for category in objectGroup.categories %}
+                                            - {{ 'category'|_ }}: <a href="{{ route('categories.show', [category.id]) }}">{{ category.name }}</a><br>
                                         {% endfor %}
                                     </td>
                                     <td>


### PR DESCRIPTION
## Summary
- Show accounts and categories within object group listings
- Drop piggy bank script from object group edit view
- Simplify object group deletion confirmation text

## Testing
- `composer unit-test` *(fails: Tests: 373, Errors: 373)*

------
https://chatgpt.com/codex/tasks/task_b_689e0d90ea448332bb69c235e5f312db