### PR TITLE
feat(frontend): add basic React settings pages

### DIFF
--- a/frontend/src/app/settings/general/page.tsx
+++ b/frontend/src/app/settings/general/page.tsx
@@ -1,0 +1,46 @@
+import Layout from '../../../components/Layout';
+
+export default function GeneralSettings() {
+    const languages = [
+        { code: 'en', name: 'English' },
+        { code: 'de', name: 'Deutsch' },
+    ];
+
+    const locales = [
+        { code: 'en_US', name: 'English (US)' },
+        { code: 'de_DE', name: 'Deutsch (DE)' },
+    ];
+
+    return (
+        <Layout title="General settings">
+            <h1 className="text-2xl mb-4">General settings</h1>
+            <form className="space-y-6">
+                <div>
+                    <label htmlFor="language" className="block mb-1 font-medium">
+                        Language
+                    </label>
+                    <select id="language" name="language" className="p-2 border rounded w-full">
+                        {languages.map((lang) => (
+                            <option key={lang.code} value={lang.code}>
+                                {lang.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label htmlFor="locale" className="block mb-1 font-medium">
+                        Locale
+                    </label>
+                    <select id="locale" name="locale" className="p-2 border rounded w-full">
+                        {locales.map((loc) => (
+                            <option key={loc.code} value={loc.code}>
+                                {loc.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            </form>
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+
+export default function SettingsIndex() {
+    return (
+        <Layout title="Settings">
+            <h1 className="text-2xl mb-4">Settings</h1>
+            <div className="space-y-6">
+                <section>
+                    <h2 className="text-xl mb-2">General</h2>
+                    <ul className="list-disc pl-6 space-y-1">
+                        <li>
+                            <Link href="/settings/general" className="text-blue-600 underline">
+                                Personal preferences
+                            </Link>
+                        </li>
+                    </ul>
+                </section>
+                <section>
+                    <h2 className="text-xl mb-2">Security</h2>
+                    <ul className="list-disc pl-6 space-y-1">
+                        <li>
+                            <Link href="/settings/security" className="text-blue-600 underline">
+                                Security options
+                            </Link>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </Layout>
+    );
+}
+

--- a/frontend/src/app/settings/security/page.tsx
+++ b/frontend/src/app/settings/security/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import Layout from '../../../components/Layout';
+
+export default function SecuritySettings() {
+    return (
+        <Layout title="Security settings">
+            <h1 className="text-2xl mb-4">Security settings</h1>
+            <ul className="list-disc pl-6 space-y-2">
+                <li>
+                    <Link href="/profile/change-email" className="text-blue-600 underline">
+                        Change email
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/profile/change-password" className="text-blue-600 underline">
+                        Change password
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/profile/mfa" className="text-blue-600 underline">
+                        Manage multi-factor authentication
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/profile/delete-account" className="text-red-600 underline">
+                        Delete account
+                    </Link>
+                </li>
+            </ul>
+        </Layout>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add Settings index page in React
- implement General settings form
- implement Security settings links

## Testing
- `npm run lint` *(fails: Invalid package.json)*
- `composer unit-test` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_b_689e0d9459fc8332af5a10a3f9eb3891