### PR TITLE
Add Spanish translations for new user setup

### DIFF
--- a/resources/lang/.gitignore
+++ b/resources/lang/.gitignore
@@ -1,3 +1,6 @@
 *
 !.gitignore
-!en_US
+!en_US/
+!en_US/**
+!es_ES/
+!es_ES/**

--- a/resources/lang/es_ES/firefly.php
+++ b/resources/lang/es_ES/firefly.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'getting_started'        => 'Primeros pasos',
+    'welcome'                => '¡Bienvenido a Firefly III!',
+    'to_get_started'         => 'Es bueno ver que ha instalado Firefly III con éxito. Para comenzar con esta herramienta, introduzca el nombre de su banco y el saldo de su cuenta corriente principal. No se preocupe si tiene varias cuentas; puede agregarlas más tarde. Firefly III solo necesita algo con lo que empezar.',
+    'savings_balance_text'   => 'Firefly III creará automáticamente una cuenta de ahorros para usted. De forma predeterminada no tendrá dinero, pero si indica su saldo se guardará así.',
+    'set_preferred_language' => 'Si prefiere usar Firefly III en otro idioma, indíquelo aquí.',
+    'currency_not_present'   => 'Si la moneda que utiliza normalmente no está en la lista, no se preocupe. Puede crear sus propias monedas en Opciones > Monedas.',
+    'finish_up_new_user'     => '¡Eso es todo! Puede continuar pulsando <strong>Enviar</strong>. Se le llevará al índice de Firefly III.',
+    'stored_new_accounts_new_user' => '¡Yay! Tus nuevas cuentas han sido guardadas.',
+    'language'               => 'Idioma',
+    'submit'                 => 'Enviar',
+];

--- a/resources/lang/es_ES/form.php
+++ b/resources/lang/es_ES/form.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'bank_name'       => 'Nombre del banco',
+    'bank_balance'    => 'Saldo',
+    'savings_balance' => 'Saldo de ahorros',
+];


### PR DESCRIPTION
## Summary
- Provide Spanish translations for new-user onboarding text
- Add Spanish form labels for initial setup
- Allow tracking of Spanish locale files in lang directory

## Testing
- `composer unit-test` *(fails: Test code or tested code removed error handlers other than its own)*

------
https://chatgpt.com/codex/tasks/task_b_689e0d94e94c83328d307b3626daf217