### PR TITLE
Add React auth and admin pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,8 @@
     "react-dom": "19.1.0",
     "sass": "^1.90.0",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.2.0"
-    "recharts": "^2.12.0",
+    "react-chartjs-2": "^5.2.0",
+    "recharts": "^2.12.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/administrations/edit/page.tsx
+++ b/frontend/src/app/administrations/edit/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import LayoutDefault from "@/components/LayoutDefault";
+
+export default function AdministrationEdit() {
+    return (
+        <LayoutDefault title="Edit Administration">
+            <h1 className="text-2xl mb-4">Edit Administration</h1>
+            <p>Administration edit form placeholder.</p>
+        </LayoutDefault>
+    );
+}
+

--- a/frontend/src/app/administrations/page.tsx
+++ b/frontend/src/app/administrations/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import LayoutDefault from "@/components/LayoutDefault";
+
+export default function AdministrationIndex() {
+    return (
+        <LayoutDefault title="Administration">
+            <h1 className="text-2xl mb-4">Administration Dashboard</h1>
+            <p>Manage the application settings and users here.</p>
+        </LayoutDefault>
+    );
+}
+

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import LayoutGuest from "@/components/LayoutGuest";
+
+export default function LoginPage() {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+
+    return (
+        <LayoutGuest title="Login">
+            <div className="card">
+                <div className="card-body login-card-body">
+                    <form method="post">
+                        <div className="input-group mb-3">
+                            <input
+                                type="email"
+                                className="form-control"
+                                placeholder="Email"
+                                autoComplete="username"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="input-group mb-3">
+                            <input
+                                type="password"
+                                className="form-control"
+                                placeholder="Password"
+                                autoComplete="current-password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="row">
+                            <div className="col-8">
+                                <div className="form-check">
+                                    <input id="remember" className="form-check-input" type="checkbox" />
+                                    <label htmlFor="remember" className="form-check-label">
+                                        Remember me
+                                    </label>
+                                </div>
+                            </div>
+                            <div className="col-4">
+                                <button type="submit" className="btn btn-primary btn-block">
+                                    Sign in
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <p className="mt-3 mb-1">
+                        <a href="/password-reset">Forgot my password</a>
+                    </p>
+                </div>
+            </div>
+        </LayoutGuest>
+    );
+}
+

--- a/frontend/src/app/password-reset/page.tsx
+++ b/frontend/src/app/password-reset/page.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import LayoutGuest from "@/components/LayoutGuest";
+
+export default function PasswordResetPage() {
+    const [email, setEmail] = useState("");
+
+    return (
+        <LayoutGuest title="Reset Password">
+            <div className="card">
+                <div className="card-body login-card-body">
+                    <p className="login-box-msg">Reset Password</p>
+                    <form method="post">
+                        <div className="input-group mb-3">
+                            <input
+                                type="email"
+                                className="form-control"
+                                placeholder="Email"
+                                autoComplete="username"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="row">
+                            <div className="col-12">
+                                <button type="submit" className="btn btn-primary btn-block">
+                                    Send reset link
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <p className="mt-3 mb-1">
+                        <a href="/login">Back to login</a>
+                    </p>
+                </div>
+            </div>
+        </LayoutGuest>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add login and password reset pages using React
- scaffold administration dashboard and edit pages
- fix invalid `package.json` to enable npm tooling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npm install` (fails: peer dependency conflict)
- `composer unit-test` (fails: Could not open input file: vendor/bin/phpunit)


------
https://chatgpt.com/codex/tasks/task_b_689e0d965d1c8332a828f4624f9fc903