### PR TITLE
refactor: replace CSS modules with Tailwind

### DIFF
--- a/frontend/src/components/ItemList.tsx
+++ b/frontend/src/components/ItemList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from '../styles/ItemList.module.css';
 
 export interface ItemListProps<T> {
   items: T[];
@@ -8,9 +7,9 @@ export interface ItemListProps<T> {
 
 export function ItemList<T>({ items, renderItem }: ItemListProps<T>) {
   return (
-    <ul className={styles.list}>
+    <ul className="list-none p-0 m-0">
       {items.map((item, idx) => (
-        <li key={idx} className={styles.item}>
+        <li key={idx} className="p-2 border-b border-gray-200">
           {renderItem(item, idx)}
         </li>
       ))}

--- a/frontend/src/components/Message.tsx
+++ b/frontend/src/components/Message.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
-import styles from '../styles/Message.module.css';
 
 export interface MessageProps {
   type: 'success' | 'error' | 'info';
   text: string;
 }
 
+const typeClasses: Record<MessageProps['type'], string> = {
+  success: 'bg-green-100 text-green-800',
+  error: 'bg-red-100 text-red-800',
+  info: 'bg-blue-100 text-blue-800',
+};
+
 export const Message: React.FC<MessageProps> = ({ type, text }) => (
-  <div className={`${styles.message} ${styles[type]}`}>
+  <div className={`p-4 rounded ${typeClasses[type]}`}>
     {text}
   </div>
 );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from '../styles/Popup.module.css';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -12,8 +11,8 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }
   if (!isOpen) return null;
   const stop = (e: React.MouseEvent) => e.stopPropagation();
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={`${styles.content} modal-dialog modal-lg`} role="document" onClick={stop}>
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center" onClick={onClose}>
+      <div className="bg-white p-4 rounded min-w-[300px] modal-dialog modal-lg" role="document" onClick={stop}>
         <div className="modal-content">
           <div className="modal-header">
             <button type="button" className="close" aria-label="Close" onClick={onClose}>

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from '../styles/Pagination.module.css';
 
 export interface PaginationProps {
   page: number;
@@ -10,11 +9,11 @@ export interface PaginationProps {
 export const Pagination: React.FC<PaginationProps> = ({ page, totalPages, onChange }) => {
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
   return (
-    <nav className={styles.pagination}>
+    <nav className="flex gap-2">
       {pages.map(p => (
         <span
           key={p}
-          className={`${styles.page} ${p === page ? styles.active : ''}`}
+          className={`px-3 py-2 border border-gray-300 cursor-pointer ${p === page ? 'bg-blue-500 text-white' : ''}`}
           onClick={() => onChange(p)}
         >
           {p}

--- a/frontend/src/components/Popup.tsx
+++ b/frontend/src/components/Popup.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from '../styles/Popup.module.css';
 
 export interface PopupProps {
   isOpen: boolean;
@@ -10,8 +9,8 @@ export interface PopupProps {
 export const Popup: React.FC<PopupProps> = ({ isOpen, onClose, children }) => {
   if (!isOpen) return null;
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.content} onClick={e => e.stopPropagation()}>
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center" onClick={onClose}>
+      <div className="bg-white p-4 rounded min-w-[300px]" onClick={e => e.stopPropagation()}>
         {children}
       </div>
     </div>

--- a/frontend/src/styles/ItemList.module.css
+++ b/frontend/src/styles/ItemList.module.css
@@ -1,2 +1,0 @@
-.list { list-style: none; padding: 0; margin: 0; }
-.item { padding: 0.5rem; border-bottom: 1px solid #eee; }

--- a/frontend/src/styles/Message.module.css
+++ b/frontend/src/styles/Message.module.css
@@ -1,4 +1,0 @@
-.message { padding: 1rem; border-radius: 0.25rem; }
-.success { background-color: #d4edda; color: #155724; }
-.error { background-color: #f8d7da; color: #721c24; }
-.info { background-color: #d1ecf1; color: #0c5460; }

--- a/frontend/src/styles/Pagination.module.css
+++ b/frontend/src/styles/Pagination.module.css
@@ -1,3 +1,0 @@
-.pagination { display:flex; gap:0.5rem; }
-.page { padding:0.5rem 0.75rem; border:1px solid #ccc; cursor:pointer; }
-.active { background:#007bff; color:white; }

--- a/frontend/src/styles/Popup.module.css
+++ b/frontend/src/styles/Popup.module.css
@@ -1,2 +1,0 @@
-.overlay { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
-.content { background:white; padding:1rem; border-radius:0.25rem; min-width:300px; }


### PR DESCRIPTION
## Summary
- migrate component-specific CSS modules to Tailwind classes
- remove obsolete CSS module files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in tags pages)


------
https://chatgpt.com/codex/tasks/task_b_689f10c0b98c8332b94051dace50b746