### PR TITLE
feat(frontend): add tailwind navigation to sidebar

### DIFF
--- a/frontend/src/components/LayoutDefault.tsx
+++ b/frontend/src/components/LayoutDefault.tsx
@@ -30,7 +30,20 @@ export default function LayoutDefault({children, title, styles, definitions, scr
                 </header>
                 <div className="flex flex-1">
                     <aside className="w-64 bg-gray-100 p-4 hidden md:block">
-                        <section className="sidebar" />
+                        <nav className="space-y-2 text-sm">
+                            <Link
+                                href="/"
+                                className="block px-2 py-1 text-gray-700 hover:bg-gray-200 rounded"
+                            >
+                                Dashboard
+                            </Link>
+                            <Link
+                                href="/accounts"
+                                className="block px-2 py-1 text-gray-700 hover:bg-gray-200 rounded"
+                            >
+                                Accounts
+                            </Link>
+                        </nav>
                     </aside>
                     <main className="flex-1 p-4">
                         {children}


### PR DESCRIPTION
## Summary
- replace placeholder sidebar section with Tailwind-styled navigation links

## Testing
- `npm ci --legacy-peer-deps`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in other files)*

------
https://chatgpt.com/codex/tasks/task_b_689f172372d48332986a0a85c1954990