### PR TITLE
Refactor empty state layout to Tailwind

### DIFF
--- a/frontend/src/components/partials/Empty.tsx
+++ b/frontend/src/components/partials/Empty.tsx
@@ -19,17 +19,20 @@ const Empty: React.FC<EmptyProps> = ({
 }) => {
   const key = (suffix: string) => translate(`no_${type}_${suffix}_${objectType}`);
   return (
-    <div className="row">
-      <div className="col-lg-6 col-md-6 col-sm-12 col-xs-12 col-lg-offset-3 col-md-offset-3">
-        <div className="box box-success">
-          <div className="box-header with-border">
-            <h3 className="box-title">{key("title")}</h3>
+    <div className="flex justify-center">
+      <div className="w-full max-w-2xl">
+        <div className="bg-white border rounded shadow">
+          <div className="border-b px-4 py-2">
+            <h3 className="text-lg font-semibold">{key("title")}</h3>
           </div>
-          <div className="box-body">
+          <div className="p-4">
             <p>{key("intro")}</p>
             <p>{key("imperative")}</p>
-            <p style={{ textAlign: "center" }}>
-              <a className="btn btn-lg btn-success" href={route}>
+            <p className="text-center">
+              <a
+                className="inline-block px-6 py-3 text-lg font-semibold text-white bg-green-500 rounded hover:bg-green-600"
+                href={route}
+              >
                 {key("create")}
               </a>
             </p>

--- a/resources/views/partials/empty.twig
+++ b/resources/views/partials/empty.twig
@@ -1,11 +1,11 @@
-<div class="row">
-    <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12 col-lg-offset-3 col-md-offset-3">
-        <div class="box box-success">
-            <div class="box-header with-border">
-                <h3 class="box-title">{{ ('no_'~type~'_title_'~objectType)|_ }}</h3>
+<div class="flex justify-center">
+    <div class="w-full max-w-2xl">
+        <div class="bg-white border rounded shadow">
+            <div class="border-b px-4 py-2">
+                <h3 class="text-lg font-semibold">{{ ('no_'~type~'_title_'~objectType)|_ }}</h3>
             </div>
 
-            <div class="box-body">
+            <div class="p-4">
                 <p>
                     {{ ('no_'~type~'_intro_'~objectType)|_ }}
                 </p>
@@ -13,14 +13,14 @@
                     {{ ('no_'~type~'_imperative_'~objectType)|_ }}
 
                 </p>
-                <p style="text-align: center;">
-                    <a class="btn btn-lg btn-success" href="{{ route }}">{{ ('no_'~type~'_create_'~objectType)|_ }}</a>
+                <p class="text-center">
+                    <a class="inline-block px-6 py-3 text-lg font-semibold text-white bg-green-500 rounded hover:bg-green-600" href="{{ route }}">{{ ('no_'~type~'_create_'~objectType)|_ }}</a>
                 </p>
             </div>
 
         </div>
     </div>
+    <script type="text/javascript" nonce="{{ JS_NONCE }}">
+        forceDemoOff = true;
+    </script>
 </div>
-<script type="text/javascript" nonce="{{ JS_NONCE }}">
-    forceDemoOff = true;
-</script>


### PR DESCRIPTION
## Summary
- refactor empty Twig partial to use Tailwind flex layout and card styling
- update React empty component to match Tailwind card design and button styling

## Testing
- `cd frontend && npx eslint src/components/partials/Empty.tsx`
- `npm --prefix frontend run lint` *(fails: Unexpected any in unrelated files)*
- `npm --prefix frontend run build` *(fails: React Hooks require "use client" directive in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_689f1720b0008332ac440a4b4264de3f