### PR TITLE
refactor: replace box containers with tailwind in reports page

### DIFF
--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -44,20 +44,20 @@ export default function ReportsPage() {
   return (
     <Layout title="Reports">
       <div className="space-y-8">
-        <div className="box">
-          <div className="box-header with-border">
-            <h3 className="box-title">Account Balances</h3>
+        <div className="border rounded shadow">
+          <div className="border-b p-4">
+            <h3 className="text-lg font-semibold">Account Balances</h3>
           </div>
-          <div className="box-body">
+          <div className="p-4">
             <Line data={data} options={options} />
           </div>
         </div>
 
-        <div className="box">
-          <div className="box-header with-border">
-            <h3 className="box-title">Summary</h3>
+        <div className="border rounded shadow">
+          <div className="border-b p-4">
+            <h3 className="text-lg font-semibold">Summary</h3>
           </div>
-          <div className="box-body">
+          <div className="p-4">
             <table className="table-auto w-full">
               <tbody>
                 {summary.map((item) => (


### PR DESCRIPTION
## Summary
- refactor reports page to use Tailwind border/rounded/shadow containers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and no-img-element warnings)*
- `composer unit-test` *(fails: vendor/bin/phpunit missing)*
- `composer install` *(fails: PHP extension ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_b_689f171f12cc8332953676dd2f00ffb8