### PR TITLE
refactor: use tailwind buttons in piggy bank pages

### DIFF
--- a/frontend/src/app/piggy-banks/[id]/add/page.tsx
+++ b/frontend/src/app/piggy-banks/[id]/add/page.tsx
@@ -26,7 +26,7 @@ export default function AddToPiggyBankPage() {
             onChange={(e) => setAmount(Number(e.target.value))}
           />
         </div>
-        <button type="submit" className="btn btn-success">
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">
           Add
         </button>
       </form>

--- a/frontend/src/app/piggy-banks/[id]/delete/page.tsx
+++ b/frontend/src/app/piggy-banks/[id]/delete/page.tsx
@@ -17,7 +17,7 @@ export default function DeletePiggyBankPage() {
     <Layout title="Delete Piggy Bank">
       <form onSubmit={submit} className="space-y-4 max-w-md">
         <p>Are you sure you want to delete this piggy bank?</p>
-        <button type="submit" className="btn btn-danger">
+        <button type="submit" className="bg-red-600 text-white px-4 py-2 rounded">
           Delete
         </button>
       </form>

--- a/frontend/src/app/piggy-banks/[id]/edit/page.tsx
+++ b/frontend/src/app/piggy-banks/[id]/edit/page.tsx
@@ -49,7 +49,7 @@ export default function EditPiggyBankPage() {
             onChange={(e) => setTarget(Number(e.target.value))}
           />
         </div>
-        <button type="submit" className="btn btn-success">
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">
           Save
         </button>
       </form>

--- a/frontend/src/app/piggy-banks/[id]/remove/page.tsx
+++ b/frontend/src/app/piggy-banks/[id]/remove/page.tsx
@@ -26,7 +26,7 @@ export default function RemoveFromPiggyBankPage() {
             onChange={(e) => setAmount(Number(e.target.value))}
           />
         </div>
-        <button type="submit" className="btn btn-success">
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">
           Remove
         </button>
       </form>

--- a/frontend/src/app/piggy-banks/create/page.tsx
+++ b/frontend/src/app/piggy-banks/create/page.tsx
@@ -33,7 +33,7 @@ export default function CreatePiggyBankPage() {
             onChange={(e) => setTarget(Number(e.target.value))}
           />
         </div>
-        <button type="submit" className="btn btn-success">
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">
           Save
         </button>
       </form>

--- a/frontend/src/app/piggy-banks/page.tsx
+++ b/frontend/src/app/piggy-banks/page.tsx
@@ -30,7 +30,7 @@ export default function PiggyBanksPage() {
     <Layout title="Piggy Banks">
       <div className="space-y-4">
         <div>
-          <Link href="/piggy-banks/create" className="btn btn-success">
+          <Link href="/piggy-banks/create" className="bg-green-600 text-white px-4 py-2 rounded">
             Create new piggy bank
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- replace bootstrap button classes with Tailwind equivalents in piggy bank pages
- drop remaining `btn` placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_b_689f171cdc9883328ae5f3f3288ae197