### PR TITLE
refactor(frontend): replace btn classes with Tailwind

### DIFF
--- a/frontend/src/app/attachments/[id]/delete/page.tsx
+++ b/frontend/src/app/attachments/[id]/delete/page.tsx
@@ -23,8 +23,18 @@ export default function DeleteAttachment({ params }: { params: { id: string } })
         <Layout title="Delete attachment">
             <h1 className="text-2xl mb-4">Delete attachment</h1>
             <p className="mb-4">Are you sure you want to delete {name}?</p>
-            <button onClick={destroy} className="btn btn-danger mr-2">Delete</button>
-            <button onClick={() => router.back()} className="btn">Cancel</button>
+            <button
+                onClick={destroy}
+                className="mr-2 bg-red-600 text-white px-4 py-2 rounded"
+            >
+                Delete
+            </button>
+            <button
+                onClick={() => router.back()}
+                className="bg-gray-200 text-gray-700 px-4 py-2 rounded"
+            >
+                Cancel
+            </button>
         </Layout>
     );
 }

--- a/frontend/src/app/attachments/[id]/edit/page.tsx
+++ b/frontend/src/app/attachments/[id]/edit/page.tsx
@@ -40,7 +40,12 @@ export default function EditAttachment({ params }: { params: { id: string } }) {
                     <label className="block">Notes</label>
                     <textarea value={notes} onChange={(e) => setNotes(e.target.value)} className="w-full border" />
                 </div>
-                <button type="submit" className="btn btn-primary">Save</button>
+                <button
+                    type="submit"
+                    className="bg-blue-600 text-white px-4 py-2 rounded"
+                >
+                    Save
+                </button>
             </form>
         </Layout>
     );

--- a/frontend/src/app/attachments/page.tsx
+++ b/frontend/src/app/attachments/page.tsx
@@ -46,7 +46,12 @@ export default function AttachmentIndex() {
             <h1 className="text-2xl mb-4">Attachments</h1>
             <form onSubmit={handleUpload} className="mb-4">
                 <input type="file" name="file" />
-                <button type="submit" className="btn btn-primary ml-2">Upload</button>
+                <button
+                    type="submit"
+                    className="ml-2 bg-blue-600 text-white px-4 py-2 rounded"
+                >
+                    Upload
+                </button>
             </form>
             <table className="table-auto w-full">
                 <thead>


### PR DESCRIPTION
## Summary
- replace old `btn` classes with Tailwind utilities across attachments pages
- style cancel actions neutrally with gray background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/app/attachments/page.tsx src/app/attachments/[id]/edit/page.tsx src/app/attachments/[id]/delete/page.tsx`


------
https://chatgpt.com/codex/tasks/task_b_689f171ab3148332ad7ae3f45b3c2ea8