### PR TITLE
refactor: use tailwind in currency delete page

### DIFF
--- a/frontend/src/app/currencies/[code]/delete/page.tsx
+++ b/frontend/src/app/currencies/[code]/delete/page.tsx
@@ -15,13 +15,23 @@ export default function DeleteCurrency() {
 
     return (
         <Layout title={`Delete ${code}`}>
-            <div className="box box-danger">
-                <div className="box-body">
+            <div className="bg-red-50 border border-red-400 rounded">
+                <div className="p-4">
                     <p>Are you sure you want to delete {code}?</p>
                 </div>
-                <div className="box-footer flex justify-end space-x-2">
-                    <button onClick={() => router.back()} className="btn btn-default">Cancel</button>
-                    <button onClick={handleDelete} className="btn btn-danger">Delete</button>
+                <div className="flex justify-end space-x-2 border-t p-4">
+                    <button
+                        onClick={() => router.back()}
+                        className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        onClick={handleDelete}
+                        className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                        Delete
+                    </button>
                 </div>
             </div>
         </Layout>


### PR DESCRIPTION
## Summary
- replace legacy box classes with Tailwind styles on currency delete page
- swap action buttons for Tailwind neutral and red variants

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any in tags pages)


------
https://chatgpt.com/codex/tasks/task_b_689f1719a2548332a699700dd2be7f10