### PR TITLE
refactor: migrate legacy scripts to react modules

### DIFF
--- a/frontend/src/components/ProfileOptions.tsx
+++ b/frontend/src/components/ProfileOptions.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * Minimal profile options component used by the profile feature script.
+ * This is a placeholder for future profile related settings.
+ */
+export default function ProfileOptions() {
+    return (
+        <div>
+            <h1 className="text-xl font-bold mb-4">Profile Options</h1>
+            <p>Profile management will be implemented here.</p>
+        </div>
+    );
+}

--- a/frontend/src/features/createTransaction.tsx
+++ b/frontend/src/features/createTransaction.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import TransactionForm, { TransactionData } from '../components/TransactionForm';
+import { apiFetch } from '../lib/bootstrap';
+
+/**
+ * Entry point for creating a transaction using React. This replaces the
+ * legacy create_transaction.js Vue script.
+ */
+export default function CreateTransaction() {
+    const handleSubmit = async (data: TransactionData) => {
+        await apiFetch('/api/transactions', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+    };
+
+    return <TransactionForm onSubmit={handleSubmit} />;
+}

--- a/frontend/src/features/editTransaction.tsx
+++ b/frontend/src/features/editTransaction.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import TransactionForm, { TransactionData } from '../components/TransactionForm';
+import { apiFetch } from '../lib/bootstrap';
+
+interface Props {
+    id: string;
+    initialData: TransactionData;
+}
+
+/**
+ * Entry point for editing a transaction using React. This replaces the
+ * legacy edit_transaction.js Vue script.
+ */
+export default function EditTransaction({ id, initialData }: Props) {
+    const handleSubmit = async (data: TransactionData) => {
+        await apiFetch(`/api/transactions/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+    };
+
+    return <TransactionForm initialData={initialData} onSubmit={handleSubmit} />;
+}

--- a/frontend/src/features/i18n.ts
+++ b/frontend/src/features/i18n.ts
@@ -1,0 +1,19 @@
+/**
+ * Small i18n helper inspired by the original Vue based implementation.
+ * This uses a simple dictionary lookup and does not depend on VueI18n.
+ */
+
+export const messages = {
+    en: {
+        greeting: 'Hello',
+    },
+    nl: {
+        greeting: 'Hallo',
+    },
+};
+
+export type Locale = keyof typeof messages;
+
+export function t(key: string, locale: Locale = 'en'): string {
+    return messages[locale][key] ?? key;
+}

--- a/frontend/src/features/profile.tsx
+++ b/frontend/src/features/profile.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ProfileOptions from '../components/ProfileOptions';
+
+/**
+ * Entry point for the profile screen, replacing the legacy profile.js
+ * Vue script with a simple React component.
+ */
+export default function Profile() {
+    return <ProfileOptions />;
+}

--- a/frontend/src/lib/app-react.ts
+++ b/frontend/src/lib/app-react.ts
@@ -1,0 +1,15 @@
+/**
+ * Base file for React powered screens. The original app_vue.js bootstrapped
+ * Vue and several plugins. In the React/Next.js frontend we only expose
+ * React to the global scope for legacy scripts that may still expect a
+ * global framework instance.
+ */
+
+import React from 'react';
+
+if (typeof window !== 'undefined') {
+    // Expose React similar to how Vue was previously exposed.
+    (window as any).React = React;
+}
+
+export default React;

--- a/frontend/src/lib/app.ts
+++ b/frontend/src/lib/app.ts
@@ -1,0 +1,8 @@
+/**
+ * React equivalent of the legacy app.js file. The old implementation
+ * loaded jQuery and Bootstrap; in the Next.js frontend we rely on the
+ * modern React stack and TailwindCSS, so this module simply re-exports
+ * shared utilities.
+ */
+
+export { apiFetch } from './bootstrap';

--- a/frontend/src/lib/bootstrap.ts
+++ b/frontend/src/lib/bootstrap.ts
@@ -1,0 +1,21 @@
+/**
+ * Modern replacement for the legacy bootstrap.js script.
+ * Provides a small wrapper around the Fetch API and automatically
+ * includes the CSRF token and the X-Requested-With header.
+ */
+
+export async function apiFetch(url: string, options: RequestInit = {}) {
+    const tokenElement = document.head.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+    const headers: Record<string, string> = {
+        'X-Requested-With': 'XMLHttpRequest',
+        ...(options.headers as Record<string, string> || {})
+    };
+
+    if (tokenElement) {
+        headers['X-CSRF-TOKEN'] = tokenElement.content;
+    } else {
+        console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+    }
+
+    return fetch(url, { ...options, headers });
+}


### PR DESCRIPTION
## Summary
- add fetch-based bootstrap helper for CSRF-safe requests
- expose React utilities and feature modules for transactions, profile, and i18n

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --prefix frontend test` (fails: Missing script: "test")
- `npm --prefix frontend run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_b_689f224c10d4833286da5404d2891961