### PR TITLE
chore: port vite config to next

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,31 @@
+const path = require('path');
+const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: ['example.com']
-  }
+  },
+  webpack: (config, { dev, isServer }) => {
+    // Map Vite's aliasing (@ -> src) to Next.js
+    config.resolve = config.resolve || {};
+    config.resolve.alias = config.resolve.alias || {};
+    config.resolve.alias['@'] = path.join(__dirname, 'src');
+
+    // Enable Subresource Integrity similar to Vite's manifestSRI plugin
+    if (!isServer) {
+      config.output.crossOriginLoading = 'anonymous';
+    }
+    config.plugins.push(
+      new SubresourceIntegrityPlugin({
+        hashFuncNames: ['sha384'],
+        enabled: !dev,
+      })
+    );
+
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,8 @@
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "webpack-subresource-integrity": "^5.2.0-rc.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6740,6 +6741,25 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/webpack-subresource-integrity": {
+      "version": "5.2.0-rc.1",
+      "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-5.2.0-rc.1.tgz",
+      "integrity": "sha512-SyjlQ3VZVwpNeVPIMpYf9Qt6oTnq9G3lCcr5YNwjW9TfUoip70MlB9ZDNhJPhkHvfvajMDQwZFfDVVL1QVwnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "html-webpack-plugin": ">= 5.0.0-beta.1 < 6",
+        "webpack": "^5.12.0"
+      },
+      "peerDependenciesMeta": {
+        "html-webpack-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "chart.js": "^4.4.1",
     "next": "15.4.6",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "sass": "^1.90.0",
-    "chart.js": "^4.4.1",
     "react-chartjs-2": "^5.2.0",
-    "recharts": "^2.12.0"
+    "react-dom": "19.1.0",
+    "recharts": "^2.12.0",
+    "sass": "^1.90.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -26,6 +26,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "webpack-subresource-integrity": "^5.2.0-rc.1"
   }
 }


### PR DESCRIPTION
## Summary
- map Vite alias to Next.js via webpack config
- enable Subresource Integrity via webpack-subresource-integrity plugin
- rely on Next's built-in dev server and hot reload instead of Vite

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(errors: Unexpected any and other warnings)*

------
https://chatgpt.com/codex/tasks/task_b_689f2252b750833296d29d34c5e933da