### PR TITLE
refactor: migrate page scripts to Next.js components

### DIFF
--- a/resources/assets/v2/src/pages/accounts/index.js
+++ b/resources/assets/v2/src/pages/accounts/index.js
@@ -18,8 +18,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {useEffect} from 'react';
+import {usePageTemplate, dates} from "../template.js";
 import i18next from "i18next";
 import {format} from "date-fns";
 import formatMoney from "../../util/format-money.js";
@@ -57,8 +57,6 @@ if(sortingColumn[0] === '-') {
 page = parseInt(params.page ?? 1);
 
 
-showInternalsButton();
-showWizardButton();
 
 // TODO currency conversion
 // TODO page cleanup and recycle for transaction lists.
@@ -446,32 +444,12 @@ let index = function () {
     }
 }
 
-let comps = {index, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-
-
-    Alpine.magic("t", (el) => {
-        return (name, vars) => {
-            return i18next.t(name, vars);
-        };
-    });
-
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function AccountsPage() {
+    useEffect(() => {
+        showInternalsButton();
+        showWizardButton();
+        Alpine.magic("t", () => (name, vars) => i18next.t(name, vars));
+    }, []);
+    usePageTemplate({index, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/administrations/create.js
+++ b/resources/assets/v2/src/pages/administrations/create.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {usePageTemplate, dates} from "../template.js";
 import Post from "../../api/v1/model/user-group/post.js";
 import i18next from "i18next";
 
@@ -87,25 +86,7 @@ let administrations = function () {
     }
 }
 
-
-let comps = {administrations, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function AdministrationCreatePage() {
+    usePageTemplate({administrations, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/administrations/edit.js
+++ b/resources/assets/v2/src/pages/administrations/edit.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {usePageTemplate, dates} from "../template.js";
 import Post from "../../api/v1/model/user-group/post.js";
 import i18next from "i18next";
 import Get from "../../api/v1/model/user-group/get.js";
@@ -96,25 +95,7 @@ let administrations = function () {
     }
 }
 
-
-let comps = {administrations, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function AdministrationEditPage() {
+    usePageTemplate({administrations, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/administrations/index.js
+++ b/resources/assets/v2/src/pages/administrations/index.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {usePageTemplate, dates} from "../template.js";
 import i18next from "i18next";
 import {format} from "date-fns";
 
@@ -117,24 +116,7 @@ let index = function () {
     }
 }
 
-let comps = {index, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function AdministrationsIndexPage() {
+    usePageTemplate({index, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/dashboard/dashboard.js
+++ b/resources/assets/v2/src/pages/dashboard/dashboard.js
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import '../../boot/bootstrap.js';
-import dates from '../../pages/shared/dates.js';
+import {useEffect} from 'react';
+import {usePageTemplate, dates} from '../template.js';
 import boxes from './boxes.js';
 import accounts from './accounts.js';
 import budgets from './budgets.js';
@@ -97,25 +97,10 @@ const comps = {
     piggies
 };
 
-showInternalsButton();
-
-//let i18n;
-
-function loadPage(comps) {
-    Object.keys(comps).forEach(comp => {
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage(comps);
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage(comps);
+export default function DashboardPage() {
+    useEffect(() => {
+        showInternalsButton();
+    }, []);
+    usePageTemplate(comps);
+    return null;
 }

--- a/resources/assets/v2/src/pages/shared/dates.js
+++ b/resources/assets/v2/src/pages/shared/dates.js
@@ -35,7 +35,8 @@ import {
 import format from '../../util/format'
 import i18next from "i18next";
 
-export default () => ({
+export default function useDates() {
+    return ({
     range: {
         start: null, end: null
     },
@@ -177,3 +178,4 @@ export default () => ({
     },
 
 });
+}

--- a/resources/assets/v2/src/pages/template.js
+++ b/resources/assets/v2/src/pages/template.js
@@ -18,68 +18,31 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import {useEffect} from 'react';
 import '../../boot/bootstrap.js';
 import dates from "./shared/dates.js";
 
+export {dates};
 
-let somethings = function() {
-    return {
-        // notifications
-        // TODO duplicate code
-        notifications: {
-            error: {
-                show: false, text: '', url: '',
-            }, success: {
-                show: false, text: '', url: '',
-            }, wait: {
-                show: false, text: '',
-
-            }
-        },
-        // state of the form is stored in formState:
-        // TODO duplicate code
-        formStates: {
-            isSubmitting: false,
-            returnHereButton: false,
-            saveAsNewButton: false, // edit form only
-            resetButton: false,
-        },
-
-        // form behaviour
-        // TODO duplicate code
-        formBehaviour: {
-            formType: 'create', // or 'update'
-        },
-
-        pageProperties: {},
-        functionName() {
-
-        },
-        init() {
-
+export function usePageTemplate(comps) {
+    useEffect(() => {
+        function loadPage() {
+            Object.keys(comps).forEach(comp => {
+                console.log(`Loading page component "${comp}"`);
+                const data = comps[comp]();
+                Alpine.data(comp, () => data);
+            });
+            Alpine.start();
         }
-    }
-}
 
-
-let comps = {somethings, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+        if (window.bootstrapped) {
+            console.log('Loaded through window variable.');
+            loadPage();
+        } else {
+            document.addEventListener('firefly-iii-bootstrapped', () => {
+                console.log('Loaded through event listener.');
+                loadPage();
+            }, {once: true});
+        }
+    }, [comps]);
 }

--- a/resources/assets/v2/src/pages/transactions/create.js
+++ b/resources/assets/v2/src/pages/transactions/create.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import '../../boot/bootstrap.js';
-import dates from '../../pages/shared/dates.js';
+import {usePageTemplate, dates} from "../template.js";
 import {createEmptySplit, defaultErrorSet} from "./shared/create-empty-split.js";
 import {parseFromEntries} from "./shared/parse-from-entries.js";
 import formatMoney from "../../util/format-money.js";
@@ -563,24 +562,7 @@ let transactions = function () {
     }
 }
 
-let comps = {transactions, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function TransactionCreatePage() {
+    usePageTemplate({transactions, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/transactions/edit.js
+++ b/resources/assets/v2/src/pages/transactions/edit.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import '../../boot/bootstrap.js';
-import dates from '../../pages/shared/dates.js';
+import {usePageTemplate, dates} from "../template.js";
 import formatMoney from "../../util/format-money.js";
 import Get from "../../api/v1/model/transaction/get.js";
 import {parseDownloadedSplits} from "./shared/parse-downloaded-splits.js";
@@ -429,25 +428,7 @@ let transactions = function () {
         },
     }
 }
-
-let comps = {transactions, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function TransactionEditPage() {
+    usePageTemplate({transactions, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/transactions/index.js
+++ b/resources/assets/v2/src/pages/transactions/index.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {usePageTemplate, dates} from "../template.js";
 import i18next from "i18next";
 import {format} from "date-fns";
 import formatMoney from "../../util/format-money.js";
@@ -161,24 +160,7 @@ let index = function () {
     }
 }
 
-let comps = {index, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function TransactionsIndexPage() {
+    usePageTemplate({index, dates});
+    return null;
 }

--- a/resources/assets/v2/src/pages/transactions/show.js
+++ b/resources/assets/v2/src/pages/transactions/show.js
@@ -18,8 +18,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import '../../boot/bootstrap.js';
-import dates from "../shared/dates.js";
+import {usePageTemplate, dates} from "../template.js";
 import i18next from "i18next";
 import Get from "../../api/v1/model/transaction/get.js";
 import {parseDownloadedSplits} from "./shared/parse-downloaded-splits.js";
@@ -134,24 +133,7 @@ let show = function () {
     }
 }
 
-let comps = {show, dates};
-
-function loadPage() {
-    Object.keys(comps).forEach(comp => {
-        console.log(`Loading page component "${comp}"`);
-        let data = comps[comp]();
-        Alpine.data(comp, () => data);
-    });
-    Alpine.start();
-}
-
-// wait for load until bootstrapped event is received.
-document.addEventListener('firefly-iii-bootstrapped', () => {
-    console.log('Loaded through event listener.');
-    loadPage();
-});
-// or is bootstrapped before event is triggered.
-if (window.bootstrapped) {
-    console.log('Loaded through window variable.');
-    loadPage();
+export default function TransactionShowPage() {
+    usePageTemplate({show, dates});
+    return null;
 }


### PR DESCRIPTION
## Summary
- convert page scripts to Next.js-style components and hooks
- centralize page initialization with a reusable `usePageTemplate` hook
- expose shared `useDates` utility for date range handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace resources/assets/v2 test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689f225425c083329817a504c9e9ff3a