### PR TITLE
chore: port legacy styles into frontend

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type {Metadata} from "next";
 import "../styles/globals.scss";
+import "../styles/adminlte-filtered.scss";
+import "../styles/app.scss";
+import "../styles/grid-ff3-theme.css";
 import React from "react";
 
 export const metadata: Metadata = {

--- a/frontend/src/components/LayoutDefault.tsx
+++ b/frontend/src/components/LayoutDefault.tsx
@@ -22,6 +22,7 @@ export default function LayoutDefault({children, title, styles, definitions, scr
                 {definitions}
             </Head>
             <div id="app" className="min-h-screen flex flex-col">
+                <a href="#main-content" className="skip-links">Skip to main content</a>
                 <header className="bg-gray-800 text-white p-4">
                     <Link href="/" className="text-xl font-bold">
                         <span className="sr-only">Firefly III</span>
@@ -45,7 +46,7 @@ export default function LayoutDefault({children, title, styles, definitions, scr
                             </Link>
                         </nav>
                     </aside>
-                    <main className="flex-1 p-4">
+                    <main id="main-content" className="flex-1 p-4">
                         {children}
                     </main>
                 </div>

--- a/frontend/src/styles/adminlte-filtered.scss
+++ b/frontend/src/styles/adminlte-filtered.scss
@@ -1,0 +1,107 @@
+/*!
+ * adminlte-filtered.scss
+ * Copyright (c) 2024 james@firefly-iii.org.
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+
+// less adminlte code because the CSS is massive otherwise.
+// copied from:
+
+/*!
+ *   AdminLTE v4.0.0-rc3
+ *   Author: Colorlib
+ *   Website: AdminLTE.io <https://adminlte.io>
+ *   License: Open source - MIT <https://opensource.org/licenses/MIT>
+ */
+
+// Bootstrap Configuration
+// ---------------------------------------------------
+@import "bootstrap/scss/functions";
+
+// AdminLTE Configuration
+// ---------------------------------------------------
+@import "admin-lte/src/scss/bootstrap-variables"; // little modified are here
+
+// Bootstrap Configuration
+// ---------------------------------------------------
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/variables-dark";
+@import "bootstrap/scss/maps";
+@import "bootstrap/scss/mixins";
+@import "bootstrap/scss/utilities";
+
+// Bootstrap Layout & components
+@import "bootstrap/scss/root";
+@import "bootstrap/scss/reboot";
+@import "bootstrap/scss/type";
+@import "bootstrap/scss/images";
+@import "bootstrap/scss/containers";
+@import "bootstrap/scss/grid";
+@import "bootstrap/scss/tables";
+@import "bootstrap/scss/forms";
+@import "bootstrap/scss/buttons";
+@import "bootstrap/scss/transitions";
+@import "bootstrap/scss/dropdown";
+@import "bootstrap/scss/button-group";
+@import "bootstrap/scss/nav";
+@import "bootstrap/scss/navbar";
+@import "bootstrap/scss/card";
+//@import "bootstrap/scss/accordion";
+@import "bootstrap/scss/breadcrumb";
+@import "bootstrap/scss/pagination";
+@import "bootstrap/scss/badge";
+@import "bootstrap/scss/alert";
+@import "bootstrap/scss/progress";
+@import "bootstrap/scss/list-group";
+@import "bootstrap/scss/close";
+//@import "bootstrap/scss/toasts";
+@import "bootstrap/scss/modal";
+@import "bootstrap/scss/tooltip";
+@import "bootstrap/scss/popover";
+//@import "bootstrap/scss/carousel";
+@import "bootstrap/scss/spinners";
+@import "bootstrap/scss/offcanvas";
+@import "bootstrap/scss/placeholders";
+
+// Bootstrap Helpers
+@import "bootstrap/scss/helpers";
+
+// Bootstrap Utilities
+@import "bootstrap/scss/utilities/api";
+
+// AdminLTE Configuration
+// ---------------------------------------------------
+@import "admin-lte/src/scss/variables";
+@import "admin-lte/src/scss/variables-dark";
+@import "admin-lte/src/scss/mixins";
+
+// AdiminLTE Parts
+// ---------------------------------------------------
+@import "admin-lte/src/scss/parts/core";
+@import "admin-lte/src/scss/parts/components";
+@import "admin-lte/src/scss/parts/extra-components";
+
+//
+// Part: Pages
+//
+
+@import "admin-lte/src/scss/pages/login_and_register";
+@import "admin-lte/src/scss/parts/miscellaneous";
+
+// AdminLTE Accessibility Styles - WCAG 2.1 AA Compliance
+@import "admin-lte/src/scss/accessibility";

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -1,0 +1,99 @@
+/*!
+ * app.scss
+ * Copyright (c) 2019 james@firefly-iii.org
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+$color-mode-type: media-query;
+$link-decoration: none !default;
+$font-family-sans-serif: "Roboto", sans-serif;
+
+$danger: #CD5029 !default;
+$primary: #1E6581 !default;
+$success: #64B624 !default;
+
+// admin LTE
+@use "admin-lte/src/scss/adminlte" with (
+    $color-mode-type: $color-mode-type,
+    $link-decoration: $link-decoration,
+    $font-family-sans-serif: $font-family-sans-serif,
+    $danger: $danger,
+    $primary: $primary,
+    $success: $success
+);
+
+@use '@fortawesome/fontawesome-free/scss/variables' with (
+  $font-path: "@fortawesome/fontawesome-free/webfonts"
+);
+
+@use '@fortawesome/fontawesome-free/scss/fontawesome';
+@use '@fortawesome/fontawesome-free/scss/fa' as fa;
+@use '@fortawesome/fontawesome-free/scss/solid.scss' as fa-solid;
+@use '@fortawesome/fontawesome-free/scss/brands.scss' as fa-brands;
+@use '@fortawesome/fontawesome-free/scss/regular.scss' as fa-regular;
+
+
+// some local CSS
+.skip-links {display: none;}
+
+/*
+Remove bottom margin from unstyled lists
+ */
+.list-no-margin {margin-bottom: 0;}
+.list-no-margin li.list-indent {margin-left:1.6em;}
+
+.hover-footer {
+    overflow-x:hidden;
+    width:100%;
+    text-align:right;
+    white-space: nowrap;
+    text-overflow: ellipsis
+}
+.hover-footer:hover {
+    overflow: auto;
+    text-overflow: unset;
+    white-space: normal;
+}
+h3.hover-expand {
+    overflow-x: hidden;
+    text-overflow: ellipsis
+}
+h3.hover-expand:hover {
+    overflow-x: auto;
+}
+
+.form-control {
+    appearance: auto;
+}
+
+// edit buttons
+.hidden-edit-button {
+    cursor: pointer;
+}
+td:not(:hover) .hidden-edit-button {
+    visibility: hidden;
+}
+
+// Bootstrap
+// @import "bootstrap/scss/bootstrap";
+
+
+// @import "~bootstrap-sass/assets/stylesheets/bootstrap";
+
+// hover buttons
+
+

--- a/frontend/src/styles/grid-ff3-theme.css
+++ b/frontend/src/styles/grid-ff3-theme.css
@@ -1,0 +1,33 @@
+/*
+ * grid-ff3-theme.css
+ * Copyright (c) 2024 james@firefly-iii.org.
+ *
+ * This file is part of Firefly III (https://github.com/firefly-iii).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/* ag-theme-acmecorp.css */
+.ag-theme-firefly-iii {
+    /* --ag-odd-row-background-color: #f00; */
+}
+.ag-theme-firefly-iii .ag-root {
+    border:0;
+}
+.ag-theme-firefly-iii .ag-root-wrapper
+{
+    border:0;
+}
+
+.skip-links {display: none;}


### PR DESCRIPTION
## Summary
- copy legacy grid and AdminLTE styles into Next.js frontend
- import migrated styles globally and expose skip-link markup

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: Unexpected any in tags pages)*

------
https://chatgpt.com/codex/tasks/task_b_689f2255bde483328db62ec96a869120