### PR TITLE
feat: add express server entry point

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+
+const app = express();
+
+const port = Number(process.env.PORT) || 3000;
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+export default app;


### PR DESCRIPTION
## Summary
- add Express server initialization under backend/src

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_689fc7181c3083329c4660a5e1c04797