### PR TITLE
Add Jest health check test

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.test.ts']
+};
+
+export default config;

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -1,0 +1,15 @@
+import request from 'supertest';
+import express from 'express';
+
+const app = express();
+app.get('/health', (_req, res) => {
+  res.status(200).send('OK');
+});
+
+describe('GET /health', () => {
+  it('responds with OK', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('OK');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
         "postinstall": "patch-package --error-on-fail",
-        "test": "jest"
+        "test": "jest --config backend/jest.config.ts"
     },
     "workspaces": [
         "resources/assets/v1",


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest for backend tests
- add health check test using supertest
- wire npm test to use backend Jest config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a13e549eec83329d20b7e634332fdd