### PR TITLE
feat: mount API routes under /api/v1

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,2 +1,17 @@
-// Placeholder exports for routes
-export {};
+import { Application, Router } from 'express';
+import healthRouter from './health';
+
+/**
+ * Mount all application routes under /api/v1.
+ *
+ * @param app Express application instance
+ */
+export default function mountRoutes(app: Application): void {
+  const apiRouter = Router();
+
+  // register sub-routers
+  apiRouter.use('/health', healthRouter);
+
+  app.use('/api/v1', apiRouter);
+}
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,10 @@
 import express from 'express';
-import healthRouter from './routes/health';
+import mountRoutes from './routes';
 import errorHandler from './middleware/errorHandler';
 
 const app = express();
 
-app.use('/health', healthRouter);
+mountRoutes(app);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- centralize API routing under `/api/v1`
- wire route mounting into Express server

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix backend run build` *(fails: File ... jest.config.ts is not under 'rootDir')*


------
https://chatgpt.com/codex/tasks/task_b_68a1d53afdac833290940e3d5249b6e5