### PR TITLE
Add auth, throttle, and locale middleware

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction } from 'express';
+
+export default function auth(req: Request, res: Response, next: NextFunction) {
+  const header = req.headers['authorization'];
+  if (!header) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  return next();
+}

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -1,3 +1,4 @@
-
-// Placeholder exports for middleware
-export {};
+export { default as errorHandler } from './errorHandler';
+export { default as auth } from './auth';
+export { default as throttle } from './throttle';
+export { default as locale } from './locale';

--- a/backend/src/middleware/locale.ts
+++ b/backend/src/middleware/locale.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from 'express';
+
+export default function locale(req: Request, _res: Response, next: NextFunction) {
+  const header = req.headers['accept-language'];
+  const lang = Array.isArray(header)
+    ? header[0]
+    : (header || '').split(',')[0];
+  (req as any).locale = lang || 'en';
+  return next();
+}

--- a/backend/src/middleware/throttle.ts
+++ b/backend/src/middleware/throttle.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+
+const requests = new Map<string, { count: number; time: number }>();
+const WINDOW_MS = 60 * 1000;
+const MAX_REQUESTS = 60;
+
+export default function throttle(req: Request, res: Response, next: NextFunction) {
+  const now = Date.now();
+  const ip = req.ip;
+  const record = requests.get(ip) || { count: 0, time: now };
+
+  if (now - record.time > WINDOW_MS) {
+    record.count = 1;
+    record.time = now;
+  } else {
+    record.count += 1;
+  }
+
+  requests.set(ip, record);
+
+  if (record.count > MAX_REQUESTS) {
+    return res.status(429).json({ error: 'Too Many Requests' });
+  }
+
+  return next();
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,2 +1,13 @@
-// Placeholder exports for routes
-export {};
+import { Router } from 'express';
+import healthRouter from './health';
+import { auth, throttle, locale } from '../middleware';
+
+const router = Router();
+
+router.use(locale);
+router.use(throttle);
+router.use(auth);
+
+router.use('/health', healthRouter);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,10 @@
 import express from 'express';
-import healthRouter from './routes/health';
-import errorHandler from './middleware/errorHandler';
+import router from './routes';
+import { errorHandler } from './middleware';
 
 const app = express();
 
-app.use('/health', healthRouter);
+app.use(router);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add basic auth, throttle, and locale Express middlewares
- centralize middleware exports and wire them into route index
- route server through new router and middlewares

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix backend run build` *(fails: TS6059: File '../backend/jest.config.ts' is not under 'rootDir')*


------
https://chatgpt.com/codex/tasks/task_b_68a1d53d4120833280bd0dd952baf0bc