### PR TITLE
Add autocomplete routes and controllers

### DIFF
--- a/backend/src/controllers/autocomplete/accounts.ts
+++ b/backend/src/controllers/autocomplete/accounts.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Account');

--- a/backend/src/controllers/autocomplete/bills.ts
+++ b/backend/src/controllers/autocomplete/bills.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Bill');

--- a/backend/src/controllers/autocomplete/budgets.ts
+++ b/backend/src/controllers/autocomplete/budgets.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Budget');

--- a/backend/src/controllers/autocomplete/categories.ts
+++ b/backend/src/controllers/autocomplete/categories.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Category');

--- a/backend/src/controllers/autocomplete/currencies.ts
+++ b/backend/src/controllers/autocomplete/currencies.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Currency');

--- a/backend/src/controllers/autocomplete/factory.ts
+++ b/backend/src/controllers/autocomplete/factory.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+
+export type AutocompleteItem = { id: string; name: string };
+
+function buildItems(prefix: string): AutocompleteItem[] {
+  return Array.from({ length: 5 }).map((_, i) => ({
+    id: String(i + 1),
+    name: `${prefix} ${i + 1}`,
+  }));
+}
+
+export function createAutocompleteHandler(prefix: string) {
+  const items = buildItems(prefix);
+  return (req: Request, res: Response) => {
+    const query = typeof req.query.query === 'string' ? req.query.query.toLowerCase() : '';
+    const filtered = query
+      ? items.filter((item) => item.name.toLowerCase().includes(query))
+      : items;
+    res.json(filtered);
+  };
+}
+

--- a/backend/src/controllers/autocomplete/index.ts
+++ b/backend/src/controllers/autocomplete/index.ts
@@ -1,0 +1,13 @@
+export { default as accounts } from './accounts';
+export { default as bills } from './bills';
+export { default as budgets } from './budgets';
+export { default as categories } from './categories';
+export { default as currencies } from './currencies';
+export { default as objectGroups } from './objectGroups';
+export { default as piggyBanks } from './piggyBanks';
+export { default as recurrences } from './recurrences';
+export { default as rules } from './rules';
+export { default as ruleGroups } from './ruleGroups';
+export { default as tags } from './tags';
+export { default as transactions } from './transactions';
+export { default as transactionTypes } from './transactionTypes';

--- a/backend/src/controllers/autocomplete/objectGroups.ts
+++ b/backend/src/controllers/autocomplete/objectGroups.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Object Group');

--- a/backend/src/controllers/autocomplete/piggyBanks.ts
+++ b/backend/src/controllers/autocomplete/piggyBanks.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Piggy Bank');

--- a/backend/src/controllers/autocomplete/recurrences.ts
+++ b/backend/src/controllers/autocomplete/recurrences.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Recurrence');

--- a/backend/src/controllers/autocomplete/ruleGroups.ts
+++ b/backend/src/controllers/autocomplete/ruleGroups.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Rule Group');

--- a/backend/src/controllers/autocomplete/rules.ts
+++ b/backend/src/controllers/autocomplete/rules.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Rule');

--- a/backend/src/controllers/autocomplete/tags.ts
+++ b/backend/src/controllers/autocomplete/tags.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Tag');

--- a/backend/src/controllers/autocomplete/transactionTypes.ts
+++ b/backend/src/controllers/autocomplete/transactionTypes.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Transaction Type');

--- a/backend/src/controllers/autocomplete/transactions.ts
+++ b/backend/src/controllers/autocomplete/transactions.ts
@@ -1,0 +1,2 @@
+import { createAutocompleteHandler } from './factory';
+export default createAutocompleteHandler('Transaction');

--- a/backend/src/routes/autocomplete.ts
+++ b/backend/src/routes/autocomplete.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import * as controller from '../controllers/autocomplete';
+
+const router = Router();
+
+router.get('/accounts', controller.accounts);
+router.get('/bills', controller.bills);
+router.get('/budgets', controller.budgets);
+router.get('/categories', controller.categories);
+router.get('/currencies', controller.currencies);
+router.get('/object-groups', controller.objectGroups);
+router.get('/piggy-banks', controller.piggyBanks);
+router.get('/recurrences', controller.recurrences);
+router.get('/rules', controller.rules);
+router.get('/rule-groups', controller.ruleGroups);
+router.get('/tags', controller.tags);
+router.get('/transactions', controller.transactions);
+router.get('/transaction-types', controller.transactionTypes);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import healthRouter from './routes/health';
+import autocompleteRouter from './routes/autocomplete';
 import errorHandler from './middleware/errorHandler';
 
 const app = express();
 
 app.use('/health', healthRouter);
+app.use('/autocomplete', autocompleteRouter);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary
- add Express routes for various autocomplete endpoints
- implement reusable factory to generate placeholder autocomplete results
- wire new autocomplete routes into server

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: husky not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d53ed804833298be352b07233bd8