### PR TITLE
feat: add exchange rate routes

### DIFF
--- a/backend/src/controllers/exchangeRates/delete.ts
+++ b/backend/src/controllers/exchangeRates/delete.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+
+const deleteExchangeRate = (req: Request, res: Response) => {
+  const { id } = req.params;
+  res.json({ message: `delete exchange rate ${id}` });
+};
+
+export default deleteExchangeRate;

--- a/backend/src/controllers/exchangeRates/list.ts
+++ b/backend/src/controllers/exchangeRates/list.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express';
+
+const listExchangeRates = (_req: Request, res: Response) => {
+  res.json({ message: 'list exchange rates' });
+};
+
+export default listExchangeRates;

--- a/backend/src/controllers/exchangeRates/show.ts
+++ b/backend/src/controllers/exchangeRates/show.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+
+const showExchangeRate = (req: Request, res: Response) => {
+  const { id } = req.params;
+  res.json({ message: `show exchange rate ${id}` });
+};
+
+export default showExchangeRate;

--- a/backend/src/controllers/exchangeRates/store.ts
+++ b/backend/src/controllers/exchangeRates/store.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+
+const storeExchangeRate = (req: Request, res: Response) => {
+  const data = req.body;
+  res.status(201).json({ message: 'store exchange rate', data });
+};
+
+export default storeExchangeRate;

--- a/backend/src/controllers/exchangeRates/update.ts
+++ b/backend/src/controllers/exchangeRates/update.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from 'express';
+
+const updateExchangeRate = (req: Request, res: Response) => {
+  const { id } = req.params;
+  const data = req.body;
+  res.json({ message: `update exchange rate ${id}`, data });
+};
+
+export default updateExchangeRate;

--- a/backend/src/controllers/index.ts
+++ b/backend/src/controllers/index.ts
@@ -1,2 +1,5 @@
-// Placeholder exports for controllers
-export {};
+export { default as listExchangeRates } from './exchangeRates/list';
+export { default as showExchangeRate } from './exchangeRates/show';
+export { default as storeExchangeRate } from './exchangeRates/store';
+export { default as updateExchangeRate } from './exchangeRates/update';
+export { default as deleteExchangeRate } from './exchangeRates/delete';

--- a/backend/src/routes/exchangeRates.ts
+++ b/backend/src/routes/exchangeRates.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  listExchangeRates,
+  showExchangeRate,
+  storeExchangeRate,
+  updateExchangeRate,
+  deleteExchangeRate,
+} from '../controllers';
+
+const router = Router();
+
+router.get('/', listExchangeRates);
+router.get('/:id', showExchangeRate);
+router.post('/', storeExchangeRate);
+router.put('/:id', updateExchangeRate);
+router.delete('/:id', deleteExchangeRate);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import healthRouter from './routes/health';
+import exchangeRatesRouter from './routes/exchangeRates';
 import errorHandler from './middleware/errorHandler';
 
 const app = express();
 
 app.use('/health', healthRouter);
+app.use('/exchange-rates', exchangeRatesRouter);
 
 app.use(errorHandler);
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
## Summary
- add controllers for listing, showing, storing, updating and deleting exchange rates
- wire up exchange rate routes and mount in server
- enable esModuleInterop for backend TypeScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a1d540572c8332a0e67d3f5e445769